### PR TITLE
track vc type for VC_VERIFIED* events

### DIFF
--- a/sdk/browser/package-lock.json
+++ b/sdk/browser/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@affinidi/wallet-browser-sdk",
-	"version": "1.3.3",
+	"version": "1.3.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/sdk/browser/package.json
+++ b/sdk/browser/package.json
@@ -40,7 +40,7 @@
   "license": "ISC",
   "dependencies": {
     "@affinidi/common": "1.1.1",
-    "@affinidi/wallet-core-sdk": "1.3.3",
+    "@affinidi/wallet-core-sdk": "1.3.4",
     "@sentry/browser": "^5.18.0",
     "bip32": "^2.0.5",
     "eccrypto-js": "^5.0.0"

--- a/sdk/browser/package.json
+++ b/sdk/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@affinidi/wallet-browser-sdk",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "SDK monorepo for affinity DID solution for browser",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/sdk/core/package-lock.json
+++ b/sdk/core/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@affinidi/wallet-core-sdk",
-	"version": "1.3.3",
+	"version": "1.3.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/sdk/core/package.json
+++ b/sdk/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@affinidi/wallet-core-sdk",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "SDK core monorepo for affinity DID solution",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/sdk/core/src/CommonNetworkMember.ts
+++ b/sdk/core/src/CommonNetworkMember.ts
@@ -1833,32 +1833,35 @@ export class CommonNetworkMember {
     const verifierDid = this.did
 
     for (const credential of credentials) {
-      this._sendVCVerifiedMetric(holderDid)
+      const metadata = { vcType: credential.type }
+      this._sendVCVerifiedMetric(holderDid, metadata)
 
-      this._sendVCVerifiedPerPartyMetric(credential.id, verifierDid)
+      this._sendVCVerifiedPerPartyMetric(credential.id, verifierDid, metadata)
     }
   }
 
   /* istanbul ignore next: private method */
-  private _sendVCVerifiedMetric(holderDid: string) {
+  private _sendVCVerifiedMetric(holderDid: string, metadata: EventMetadata) {
     const event = {
       link: holderDid,
       name: EventName.VC_VERIFIED,
       category: EventCategory.VC,
       subCategory: 'verify',
+      metadata: metadata,
     }
 
     this._metricsService.send(event)
   }
 
   /* istanbul ignore next: private method */
-  private _sendVCVerifiedPerPartyMetric(vcId: string, verifierDid: string) {
+  private _sendVCVerifiedPerPartyMetric(vcId: string, verifierDid: string, metadata: EventMetadata) {
     const event = {
       link: vcId,
       secondaryLink: verifierDid,
       name: EventName.VC_VERIFIED_PER_PARTY,
       category: EventCategory.VC,
       subCategory: 'verify',
+      metadata: metadata,
     }
 
     this._metricsService.send(event)

--- a/sdk/expo/package-lock.json
+++ b/sdk/expo/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@affinidi/wallet-expo-sdk",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/sdk/expo/package.json
+++ b/sdk/expo/package.json
@@ -41,7 +41,7 @@
   "license": "ISC",
   "dependencies": {
     "@affinidi/common": "1.1.1",
-    "@affinidi/wallet-core-sdk": "1.3.3",
+    "@affinidi/wallet-core-sdk": "1.3.4",
     "@react-native-community/netinfo": "^5.5.1",
     "@types/text-encoding": "0.0.35",
     "assert": "^2.0.0",

--- a/sdk/expo/package.json
+++ b/sdk/expo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@affinidi/wallet-expo-sdk",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "SDK monorepo for affinity DID solution for Expo",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/sdk/react-native/package-lock.json
+++ b/sdk/react-native/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@affinidi/wallet-react-native-sdk",
-	"version": "1.3.3",
+	"version": "1.3.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/sdk/react-native/package.json
+++ b/sdk/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@affinidi/wallet-react-native-sdk",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "SDK for affinity DID solution for React Native",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/sdk/react-native/package.json
+++ b/sdk/react-native/package.json
@@ -34,7 +34,7 @@
   "license": "ISC",
   "dependencies": {
     "@affinidi/common": "1.1.1",
-    "@affinidi/wallet-core-sdk": "1.3.3",
+    "@affinidi/wallet-core-sdk": "1.3.4",
     "@react-native-community/netinfo": "^5.9.3",
     "@sentry/react-native": "^1.5.0",
     "@types/text-encoding": "0.0.35",


### PR DESCRIPTION
### Story
https://replika.atlassian.net/browse/NEP-847


### Note
Events have been tested against a local metrics backend (running `affinity-metrics@0.0.80`) to make sure additional metadata are correctly stored.

Note that the integration test won't actually send the event since we have

```ts
if (isValid && !isTestEnvironment) {
  this._sendVCVerifiedMetrics(suppliedCredentials, did)
}
```

So I've tested it without specifying `NODE_ENV=test`.