### PR TITLE
Nep 845, 846 integration tests

### DIFF
--- a/.github/workflows/codeclimate-workflow-pr.yaml
+++ b/.github/workflows/codeclimate-workflow-pr.yaml
@@ -16,7 +16,7 @@ jobs:
         with:
           node-version: 12
       - name: Check for skipped tests
-        run: ! find . -maxdepth 6 -name *.test.ts -exec grep \\.only {} \;
+        run: [ $(find . -maxdepth 6 -name *.test.ts -exec grep \\.only {} \; | wc -l) -eq 0 ];
       - name: Download cc-test-reporter
         run: |
             mkdir -p tmp/

--- a/.github/workflows/codeclimate-workflow-pr.yaml
+++ b/.github/workflows/codeclimate-workflow-pr.yaml
@@ -16,7 +16,7 @@ jobs:
         with:
           node-version: 12
       - name: Check for skipped tests
-        run: find . -maxdepth 6 -name *.test.ts -exec grep \\.only {} \;
+        run: ! find . -maxdepth 6 -name *.test.ts -exec grep \\.only {} \;
       - name: Download cc-test-reporter
         run: |
             mkdir -p tmp/

--- a/.github/workflows/codeclimate-workflow-pr.yaml
+++ b/.github/workflows/codeclimate-workflow-pr.yaml
@@ -16,7 +16,8 @@ jobs:
         with:
           node-version: 12
       - name: Check for skipped tests
-        run: [ $(find . -maxdepth 6 -name *.test.ts -exec grep \\.only {} \; | wc -l) -eq 0 ];
+        run: |
+            [ $(find . -maxdepth 6 -name *.test.ts -exec grep \\.only {} \; | wc -l) -eq 0 ];
       - name: Download cc-test-reporter
         run: |
             mkdir -p tmp/

--- a/.github/workflows/codeclimate-workflow-pr.yaml
+++ b/.github/workflows/codeclimate-workflow-pr.yaml
@@ -8,6 +8,8 @@ jobs:
     name: CodeClimate Trigger
     runs-on: ubuntu-latest
     steps:
+      - name: Check for skipped tests
+        run: find . -maxdepth 6 -name *.test.ts -exec grep \\.only {} \;
       - name: Set env vars
         id: vars
         run: echo "::set-output name=pr_key::$(echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { print $3 }')"

--- a/.github/workflows/codeclimate-workflow-pr.yaml
+++ b/.github/workflows/codeclimate-workflow-pr.yaml
@@ -8,8 +8,6 @@ jobs:
     name: CodeClimate Trigger
     runs-on: ubuntu-latest
     steps:
-      - name: Check for skipped tests
-        run: find . -maxdepth 6 -name *.test.ts -exec grep \\.only {} \;
       - name: Set env vars
         id: vars
         run: echo "::set-output name=pr_key::$(echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { print $3 }')"
@@ -17,6 +15,8 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 12
+      - name: Check for skipped tests
+        run: find . -maxdepth 6 -name *.test.ts -exec grep \\.only {} \;
       - name: Download cc-test-reporter
         run: |
             mkdir -p tmp/

--- a/sdk/core/test/integration/NetworkMember.test.ts
+++ b/sdk/core/test/integration/NetworkMember.test.ts
@@ -54,7 +54,7 @@ import { generateUsername } from '../helpers/generateUsername'
 // test agains `dev | prod` // if nothing specified, staging is used by default
 const options: SdkOptions = getOptionsForEnvironment()
 
-describe('CommonNetworkMember', () => {
+describe.only('CommonNetworkMember', () => {
   const callbackUrl = 'https://kudos-issuer-backend.affinity-project.org/kudos_offering/'
 
   const offeredCredentials = [
@@ -91,7 +91,7 @@ describe('CommonNetworkMember', () => {
 
   // This started failing with this error: LimitExceededException: Attempt limit exceeded, please try after some time.
   // Also it's not clear how this tests the resending of the OTP.
-  it.only('resends OTP when UNCONFIRMED user signs up (for the Nth time)', async () => {
+  it('resends OTP when UNCONFIRMED user signs up (for the Nth time)', async () => {
     const username = emailUnconfirmed
 
     await CommonNetworkMember.signUp(username, cognitoPassword)

--- a/sdk/core/test/integration/NetworkMember.test.ts
+++ b/sdk/core/test/integration/NetworkMember.test.ts
@@ -69,7 +69,7 @@ describe.only('CommonNetworkMember', () => {
     },
   ]
 
-  it('#throws `COR-4 / 400` when UNCONFIRMED user signs in', async () => {
+  it.only('#throws `COR-4 / 400` when UNCONFIRMED user signs in', async () => {
     const username = emailUnconfirmed
 
     await CommonNetworkMember.signUp(username, cognitoPassword, options)

--- a/sdk/core/test/integration/NetworkMember.test.ts
+++ b/sdk/core/test/integration/NetworkMember.test.ts
@@ -54,7 +54,7 @@ import { generateUsername } from '../helpers/generateUsername'
 // test agains `dev | prod` // if nothing specified, staging is used by default
 const options: SdkOptions = getOptionsForEnvironment()
 
-describe.only('CommonNetworkMember', () => {
+describe('CommonNetworkMember', () => {
   const callbackUrl = 'https://kudos-issuer-backend.affinity-project.org/kudos_offering/'
 
   const offeredCredentials = [
@@ -69,7 +69,7 @@ describe.only('CommonNetworkMember', () => {
     },
   ]
 
-  it.only('#throws `COR-4 / 400` when UNCONFIRMED user signs in', async () => {
+  it('#throws `COR-4 / 400` when UNCONFIRMED user signs in', async () => {
     const username = emailUnconfirmed
 
     await CommonNetworkMember.signUp(username, cognitoPassword, options)


### PR DESCRIPTION
uncomment integration tests
add a GH actions step to check for skipped tests

Proof that it fails if `.only` is found in test files

![Screen Shot 2020-10-14 at 7 27 48 AM](https://user-images.githubusercontent.com/4401444/95983148-25f39f80-0def-11eb-8f09-998db110a688.png)
