### PR TITLE
Fixed method name typo: setEnvironmentVarialbles

### DIFF
--- a/sdk/browser/src/AffinityWallet.ts
+++ b/sdk/browser/src/AffinityWallet.ts
@@ -14,7 +14,7 @@ export class AffinityWallet extends CoreNetwork {
   constructor(password: string, encryptedSeed: string, options: __dangerous.SdkOptions = {}) {
     super(password, encryptedSeed, options)
 
-    const sdkOptions = CoreNetwork.setEnvironmentVarialbles(options)
+    const sdkOptions = CoreNetwork.setEnvironmentVariables(options)
 
     this.keysService = new KeysService(encryptedSeed, password)
     this.walletStorageService = new WalletStorageService(encryptedSeed, password, sdkOptions)
@@ -31,7 +31,7 @@ export class AffinityWallet extends CoreNetwork {
       { isArray: false, type: __dangerous.SdkOptions, isRequired: false, value: options },
     ])
 
-    const { keyStorageUrl, userPoolId } = CoreNetwork.setEnvironmentVarialbles(options)
+    const { keyStorageUrl, userPoolId } = CoreNetwork.setEnvironmentVariables(options)
     const { accessToken } = __dangerous.readUserTokensFromSessionStorage(userPoolId)
 
     const encryptedSeed = await WalletStorageService.pullEncryptedSeed(accessToken, keyStorageUrl)

--- a/sdk/core/src/CommonNetworkMember.ts
+++ b/sdk/core/src/CommonNetworkMember.ts
@@ -126,7 +126,7 @@ export class CommonNetworkMember {
       throw new Error('`password` and `encryptedSeed` must be provided!')
     }
 
-    this._sdkOptions = CommonNetworkMember.setEnvironmentVarialbles(options)
+    this._sdkOptions = CommonNetworkMember.setEnvironmentVariables(options)
 
     const {
       issuerUrl,
@@ -182,7 +182,7 @@ export class CommonNetworkMember {
     return accessApiKey
   }
 
-  protected static setEnvironmentVarialbles(options: SdkOptions) {
+  protected static setEnvironmentVariables(options: SdkOptions) {
     const env = options.env || 'staging'
 
     let vaultUrl
@@ -363,7 +363,7 @@ export class CommonNetworkMember {
       { isArray: false, type: SdkOptions, isRequired: false, value: options },
     ])
 
-    // const { registryUrl } = CommonNetworkMember.setEnvironmentVarialbles(options)
+    // const { registryUrl } = CommonNetworkMember.setEnvironmentVariables(options)
     /* istanbul ignore next: seems options is {} if not passed to the method */
     options = options || {}
 
@@ -393,7 +393,7 @@ export class CommonNetworkMember {
     nonce: number,
     options: SdkOptions = {},
   ) {
-    const { registryUrl } = CommonNetworkMember.setEnvironmentVarialbles(options)
+    const { registryUrl } = CommonNetworkMember.setEnvironmentVariables(options)
 
     const accessApiKey = CommonNetworkMember._setAccessApiKey(options)
 
@@ -584,7 +584,7 @@ export class CommonNetworkMember {
       { isArray: false, type: MessageParameters, isRequired: false, value: messageParameters },
     ])
 
-    const { userPoolId, clientId } = CommonNetworkMember.setEnvironmentVarialbles(options)
+    const { userPoolId, clientId } = CommonNetworkMember.setEnvironmentVariables(options)
 
     const cognitoService = new CognitoService({ userPoolId, clientId })
     const token = await cognitoService.signInWithUsername(username, messageParameters)
@@ -607,7 +607,7 @@ export class CommonNetworkMember {
       { isArray: false, type: SdkOptions, isRequired: false, value: options },
     ])
 
-    const { keyStorageUrl, userPoolId, clientId } = CommonNetworkMember.setEnvironmentVarialbles(options)
+    const { keyStorageUrl, userPoolId, clientId } = CommonNetworkMember.setEnvironmentVariables(options)
 
     /* istanbul ignore next: seems options is {} if not passed to the method */
     options = options || {}
@@ -646,7 +646,7 @@ export class CommonNetworkMember {
       { isArray: false, type: SdkOptions, isRequired: false, value: options },
     ])
 
-    const { keyStorageUrl, registryUrl } = CommonNetworkMember.setEnvironmentVarialbles(options)
+    const { keyStorageUrl, registryUrl } = CommonNetworkMember.setEnvironmentVariables(options)
 
     const credentialOfferToken = await WalletStorageService.getCredentialOffer(idToken, keyStorageUrl)
 
@@ -663,7 +663,7 @@ export class CommonNetworkMember {
   async signOut(options: SdkOptions = {}): Promise<void> {
     await ParametersValidator.validate([{ isArray: false, type: SdkOptions, isRequired: false, value: options }])
 
-    const { userPoolId, clientId } = CommonNetworkMember.setEnvironmentVarialbles(options)
+    const { userPoolId, clientId } = CommonNetworkMember.setEnvironmentVariables(options)
     const cognitoService = new CognitoService({ userPoolId, clientId })
 
     if (this.cognitoUserTokens) {
@@ -679,7 +679,7 @@ export class CommonNetworkMember {
 
   /* istanbul ignore next: private method */
   private async _refreshCognitoUserTokens(options: SdkOptions = {}): Promise<void> {
-    const { userPoolId, clientId } = CommonNetworkMember.setEnvironmentVarialbles(options)
+    const { userPoolId, clientId } = CommonNetworkMember.setEnvironmentVariables(options)
 
     const cognitoService = new CognitoService({ userPoolId, clientId })
 
@@ -707,7 +707,7 @@ export class CommonNetworkMember {
       { isArray: false, type: SdkOptions, isRequired: false, value: options },
     ])
 
-    const { userPoolId, clientId } = CommonNetworkMember.setEnvironmentVarialbles(options)
+    const { userPoolId, clientId } = CommonNetworkMember.setEnvironmentVariables(options)
 
     const cognitoService = new CognitoService({ userPoolId, clientId })
 
@@ -734,7 +734,7 @@ export class CommonNetworkMember {
       { isArray: false, type: SdkOptions, isRequired: false, value: options },
     ])
 
-    const { userPoolId, clientId } = CommonNetworkMember.setEnvironmentVarialbles(options)
+    const { userPoolId, clientId } = CommonNetworkMember.setEnvironmentVariables(options)
 
     const cognitoService = new CognitoService({ userPoolId, clientId })
 
@@ -755,7 +755,7 @@ export class CommonNetworkMember {
       { isArray: false, type: SdkOptions, isRequired: false, value: options },
     ])
 
-    const { keyStorageUrl, userPoolId, clientId } = CommonNetworkMember.setEnvironmentVarialbles(options)
+    const { keyStorageUrl, userPoolId, clientId } = CommonNetworkMember.setEnvironmentVariables(options)
 
     const cognitoService = new CognitoService({ userPoolId, clientId })
 
@@ -847,7 +847,7 @@ export class CommonNetworkMember {
 
     password = normalizeShortPassword(password, username)
 
-    const { keyStorageUrl, userPoolId, clientId } = CommonNetworkMember.setEnvironmentVarialbles(options)
+    const { keyStorageUrl, userPoolId, clientId } = CommonNetworkMember.setEnvironmentVariables(options)
 
     const cognitoService = new CognitoService({ userPoolId, clientId })
     await cognitoService.signUp(username, password, messageParameters, { keyStorageUrl, userPoolId, clientId })
@@ -930,7 +930,7 @@ export class CommonNetworkMember {
 
     const { isUsername } = validateUsername(username)
 
-    const { userPoolId, clientId, keyStorageUrl } = CommonNetworkMember.setEnvironmentVarialbles(options)
+    const { userPoolId, clientId, keyStorageUrl } = CommonNetworkMember.setEnvironmentVariables(options)
 
     const cognitoService = new CognitoService({ userPoolId, clientId })
 
@@ -1055,7 +1055,7 @@ export class CommonNetworkMember {
       { isArray: false, type: SdkOptions, isRequired: false, value: options },
     ])
 
-    const { userPoolId, clientId } = CommonNetworkMember.setEnvironmentVarialbles(options)
+    const { userPoolId, clientId } = CommonNetworkMember.setEnvironmentVariables(options)
 
     const cognitoService = new CognitoService({ userPoolId, clientId })
 
@@ -1138,7 +1138,7 @@ export class CommonNetworkMember {
       return this.cognitoUserTokens
     }
 
-    const { userPoolId } = CommonNetworkMember.setEnvironmentVarialbles(options)
+    const { userPoolId } = CommonNetworkMember.setEnvironmentVariables(options)
 
     this.cognitoUserTokens = readUserTokensFromSessionStorage(userPoolId)
 
@@ -1158,7 +1158,7 @@ export class CommonNetworkMember {
       { isArray: false, type: SdkOptions, isRequired: false, value: options },
     ])
 
-    const { userPoolId, clientId } = CommonNetworkMember.setEnvironmentVarialbles(options)
+    const { userPoolId, clientId } = CommonNetworkMember.setEnvironmentVariables(options)
 
     const { accessToken } = await this._getCognitoUserTokensForUser()
 
@@ -1179,7 +1179,7 @@ export class CommonNetworkMember {
       { isArray: false, type: SdkOptions, isRequired: false, value: options },
     ])
 
-    const { userPoolId, clientId } = CommonNetworkMember.setEnvironmentVarialbles(options)
+    const { userPoolId, clientId } = CommonNetworkMember.setEnvironmentVariables(options)
 
     const { accessToken } = await this._getCognitoUserTokensForUser()
 

--- a/sdk/expo/src/AffinityWallet.ts
+++ b/sdk/expo/src/AffinityWallet.ts
@@ -17,7 +17,7 @@ export class AffinityWallet extends CoreNetwork {
   constructor(password: string, encryptedSeed: string, options: __dangerous.SdkOptions = {}) {
     super(password, encryptedSeed, options)
 
-    const sdkOptions = CoreNetwork.setEnvironmentVarialbles(options)
+    const sdkOptions = CoreNetwork.setEnvironmentVariables(options)
 
     this.skipBackupCredentials = options.skipBackupCredentials
 
@@ -48,7 +48,7 @@ export class AffinityWallet extends CoreNetwork {
       { isArray: false, type: __dangerous.SdkOptions, isRequired: false, value: options },
     ])
 
-    const { keyStorageUrl, userPoolId } = CoreNetwork.setEnvironmentVarialbles(options)
+    const { keyStorageUrl, userPoolId } = CoreNetwork.setEnvironmentVariables(options)
     const { accessToken } = __dangerous.readUserTokensFromSessionStorage(userPoolId)
 
     const encryptedSeed = await WalletStorageService.pullEncryptedSeed(accessToken, keyStorageUrl)

--- a/sdk/react-native/src/AffinityWallet.ts
+++ b/sdk/react-native/src/AffinityWallet.ts
@@ -14,7 +14,7 @@ export class AffinityWallet extends CoreNetwork {
   constructor(password: string, encryptedSeed: string, options: __dangerous.SdkOptions = {}) {
     super(password, encryptedSeed, options)
 
-    const sdkOptions = CoreNetwork.setEnvironmentVarialbles(options)
+    const sdkOptions = CoreNetwork.setEnvironmentVariables(options)
 
     this.keysService = new KeysService(encryptedSeed, password)
     this.walletStorageService = new WalletStorageService(encryptedSeed, password, sdkOptions)
@@ -31,7 +31,7 @@ export class AffinityWallet extends CoreNetwork {
       { isArray: false, type: __dangerous.SdkOptions, isRequired: false, value: options },
     ])
 
-    const { keyStorageUrl, userPoolId } = CoreNetwork.setEnvironmentVarialbles(options)
+    const { keyStorageUrl, userPoolId } = CoreNetwork.setEnvironmentVariables(options)
     const { accessToken } = __dangerous.readUserTokensFromSessionStorage(userPoolId)
 
     const encryptedSeed = await WalletStorageService.pullEncryptedSeed(accessToken, keyStorageUrl)


### PR DESCRIPTION
Renames `setEnvironmentVarialbles` to `setEnvironmentVariables`.
This is a minor, but breaking change as it changes the name of a publicly visible procedure.  I have identified which projects in our github require a change.
I am tempted to make the fixes and bump up the patch version (i.e. vX.Y.Z+1), but maybe we should save this for when we bump up the major version (i.e. vX+1.Y.Z)