### PR TITLE
nep-957: update event component enum to distinguish wallet implementations

### DIFF
--- a/sdk/browser/package-lock.json
+++ b/sdk/browser/package-lock.json
@@ -4,6 +4,15 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@affinidi/affinity-metrics-lib": {
+			"version": "0.0.18",
+			"resolved": "https://registry.npmjs.org/@affinidi/affinity-metrics-lib/-/affinity-metrics-lib-0.0.18.tgz",
+			"integrity": "sha512-yeorbuxXdUxuT6RenyYbvO8Ifp3J9beg4oIrE77WjxNgrtSFzhiiM98rJ6j6Peegs31YGSFWrpjDTjD56GZbPA==",
+			"requires": {
+				"keccak256": "^1.0.0",
+				"node-fetch": "^2.6.0"
+			}
+		},
 		"@affinidi/eslint-config": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@affinidi/eslint-config/-/eslint-config-1.0.1.tgz",
@@ -3684,6 +3693,24 @@
 			"integrity": "sha512-ApcjaOdVTJ7y4r08xI5wIqpvwS48Q0PBG4DJROcEkH1f8MdAiNFyFxz3xoL0LWAVwjrwPYZdVHHxhRHcx/uGLA==",
 			"dev": true
 		},
+		"keccak": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.1.tgz",
+			"integrity": "sha512-epq90L9jlFWCW7+pQa6JOnKn2Xgl2mtI664seYR6MHskvI9agt7AnDqmAlp9TqU4/caMYbA08Hi5DMZAl5zdkA==",
+			"requires": {
+				"node-addon-api": "^2.0.0",
+				"node-gyp-build": "^4.2.0"
+			}
+		},
+		"keccak256": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/keccak256/-/keccak256-1.0.1.tgz",
+			"integrity": "sha512-wJM3lUBboGc5nOH3iIkFFWnnI8km0RHspLqfedDPCHvdHFVOhArGkx27KdaqOd2/gqqMUeWBThEs8iuC4mZZHQ==",
+			"requires": {
+				"bn.js": "^4.11.8",
+				"keccak": "^3.0.1"
+			}
+		},
 		"kind-of": {
 			"version": "6.0.3",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -4384,6 +4411,11 @@
 				"path-to-regexp": "^1.7.0"
 			}
 		},
+		"node-addon-api": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
+			"integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
+		},
 		"node-environment-flags": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.6.tgz",
@@ -4401,6 +4433,16 @@
 					"dev": true
 				}
 			}
+		},
+		"node-fetch": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+			"integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+		},
+		"node-gyp-build": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
+			"integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg=="
 		},
 		"node-libs-browser": {
 			"version": "2.2.1",

--- a/sdk/browser/package-lock.json
+++ b/sdk/browser/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@affinidi/wallet-browser-sdk",
-	"version": "2.0.2",
+	"version": "2.0.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/sdk/browser/package.json
+++ b/sdk/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@affinidi/wallet-browser-sdk",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "SDK monorepo for affinity DID solution for browser",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -40,7 +40,7 @@
   "license": "ISC",
   "dependencies": {
     "@affinidi/common": "1.1.2",
-    "@affinidi/wallet-core-sdk": "2.0.2",
+    "@affinidi/wallet-core-sdk": "2.0.3",
     "@sentry/browser": "^5.18.0",
     "bip32": "^2.0.5",
     "eccrypto-js": "^5.0.0"

--- a/sdk/browser/package.json
+++ b/sdk/browser/package.json
@@ -41,6 +41,7 @@
   "dependencies": {
     "@affinidi/common": "1.1.2",
     "@affinidi/wallet-core-sdk": "2.0.3",
+    "@affinidi/affinity-metrics-lib": "0.0.18",
     "@sentry/browser": "^5.18.0",
     "bip32": "^2.0.5",
     "eccrypto-js": "^5.0.0"

--- a/sdk/browser/src/AffinityWallet.ts
+++ b/sdk/browser/src/AffinityWallet.ts
@@ -1,4 +1,5 @@
-import { CommonNetworkMember as CoreNetwork, __dangerous, EventComponent } from '@affinidi/wallet-core-sdk'
+import { CommonNetworkMember as CoreNetwork, __dangerous } from '@affinidi/wallet-core-sdk'
+import { EventComponent } from '@affinidi/affinity-metrics-lib'
 
 import KeysService from './services/KeysService'
 import WalletStorageService from './services/WalletStorageService'

--- a/sdk/browser/src/AffinityWallet.ts
+++ b/sdk/browser/src/AffinityWallet.ts
@@ -1,4 +1,4 @@
-import { CommonNetworkMember as CoreNetwork, __dangerous } from '@affinidi/wallet-core-sdk'
+import { CommonNetworkMember as CoreNetwork, __dangerous, EventComponent } from '@affinidi/wallet-core-sdk'
 
 import KeysService from './services/KeysService'
 import WalletStorageService from './services/WalletStorageService'
@@ -18,6 +18,7 @@ export class AffinityWallet extends CoreNetwork {
 
     this.keysService = new KeysService(encryptedSeed, password)
     this.walletStorageService = new WalletStorageService(encryptedSeed, password, sdkOptions)
+    this._component = EventComponent.AffinidiBrowserSDK
   }
 
   /**

--- a/sdk/browser/src/AffinityWallet.ts
+++ b/sdk/browser/src/AffinityWallet.ts
@@ -8,18 +8,24 @@ type SdkOptions = __dangerous.SdkOptions & {
   issueSignupCredential?: boolean
 }
 
+const COMPONENT = EventComponent.AffinidiBrowserSDK
+
 export class AffinityWallet extends CoreNetwork {
   keysService: KeysService
   walletStorageService: WalletStorageService
 
-  constructor(password: string, encryptedSeed: string, options: __dangerous.SdkOptions = {}) {
-    super(password, encryptedSeed, options)
+  constructor(
+    password: string,
+    encryptedSeed: string,
+    options: __dangerous.SdkOptions = {},
+    component: EventComponent = COMPONENT,
+  ) {
+    super(password, encryptedSeed, options, component)
 
     const sdkOptions = CoreNetwork.setEnvironmentVarialbles(options)
 
     this.keysService = new KeysService(encryptedSeed, password)
     this.walletStorageService = new WalletStorageService(encryptedSeed, password, sdkOptions)
-    this._component = EventComponent.AffinidiBrowserSDK
   }
 
   /**

--- a/sdk/core/package-lock.json
+++ b/sdk/core/package-lock.json
@@ -1,13 +1,13 @@
 {
 	"name": "@affinidi/wallet-core-sdk",
-	"version": "2.0.2",
+	"version": "2.0.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
 		"@affinidi/affinity-metrics-lib": {
-			"version": "0.0.12",
-			"resolved": "https://registry.npmjs.org/@affinidi/affinity-metrics-lib/-/affinity-metrics-lib-0.0.12.tgz",
-			"integrity": "sha512-uG3WZH8OLV8rxtqiq/3T2ZlCsS7CPsMvcPSRhIteZKdLhKxF8pN/27PPl9HWyTjhB2dnYHwbX3h8LQJqCCo2gg==",
+			"version": "0.0.18",
+			"resolved": "https://registry.npmjs.org/@affinidi/affinity-metrics-lib/-/affinity-metrics-lib-0.0.18.tgz",
+			"integrity": "sha512-yeorbuxXdUxuT6RenyYbvO8Ifp3J9beg4oIrE77WjxNgrtSFzhiiM98rJ6j6Peegs31YGSFWrpjDTjD56GZbPA==",
 			"requires": {
 				"keccak256": "^1.0.0",
 				"node-fetch": "^2.6.0"

--- a/sdk/core/package.json
+++ b/sdk/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@affinidi/wallet-core-sdk",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "SDK core monorepo for affinity DID solution",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -48,7 +48,7 @@
     "@affinidi/common": "1.1.2",
     "@affinidi/vc-common": "1.1.1",
     "@affinidi/vc-data": "1.1.2",
-    "@affinidi/affinity-metrics-lib": "0.0.12",
+    "@affinidi/affinity-metrics-lib": "0.0.18",
     "@types/async-retry": "^1.4.2",
     "@types/create-hash": "^1.2.2",
     "@types/jsonld": "^1.5.1",

--- a/sdk/core/src/CommonNetworkMember.ts
+++ b/sdk/core/src/CommonNetworkMember.ts
@@ -113,7 +113,7 @@ export class CommonNetworkMember {
   protected _component: EventComponent
   protected cognitoUserTokens: CognitoUserTokens
 
-  constructor(password: string, encryptedSeed: string, options: SdkOptions = {}) {
+  constructor(password: string, encryptedSeed: string, options: SdkOptions = {}, component?: EventComponent) {
     // await ParametersValidator.validateSync(
     //   [
     //     { isArray: false, type: 'string', isRequired: true, value: password },
@@ -140,7 +140,8 @@ export class CommonNetworkMember {
 
     this._accessApiKey = CommonNetworkMember._setAccessApiKey(this._sdkOptions)
 
-    this._metricsService = new MetricsService({ metricsUrl, apiKey: this._accessApiKey })
+    this._component = component
+    this._metricsService = new MetricsService({ metricsUrl, apiKey: this._accessApiKey }, this._component)
     this._api = new API(registryUrl, issuerUrl, verifierUrl, { apiKey: this._accessApiKey })
     this._walletStorageService = new WalletStorageService(encryptedSeed, password, this._sdkOptions)
     this._revocationService = new RevocationService(this._sdkOptions)
@@ -1851,7 +1852,7 @@ export class CommonNetworkMember {
       metadata: metadata,
     }
 
-    this._metricsService.send(event, this._component)
+    this._metricsService.send(event)
   }
 
   /* istanbul ignore next: private method */
@@ -1865,7 +1866,7 @@ export class CommonNetworkMember {
       metadata: metadata,
     }
 
-    this._metricsService.send(event, this._component)
+    this._metricsService.send(event)
   }
 
   private _sendVCSavedMetric(vcId: string, issuerId: string, metadata: EventMetadata) {
@@ -1878,7 +1879,7 @@ export class CommonNetworkMember {
       metadata: metadata,
     }
 
-    this._metricsService.send(event, this._component)
+    this._metricsService.send(event)
   }
 
   protected _sendVCSavedMetrics(credentials: SignedCredential[]) {

--- a/sdk/core/src/CommonNetworkMember.ts
+++ b/sdk/core/src/CommonNetworkMember.ts
@@ -4,7 +4,7 @@ import { buildVCV1Unsigned, buildVCV1Skeleton, buildVPV1Unsigned } from '@affini
 import { VCV1, VCV1SubjectBaseMA, VPV1, VCV1Unsigned } from '@affinidi/vc-common'
 import { parse } from 'did-resolver'
 
-import { EventCategory, EventName, EventMetadata } from '@affinidi/affinity-metrics-lib'
+import { EventComponent, EventCategory, EventName, EventMetadata } from '@affinidi/affinity-metrics-lib'
 
 import API from './services/ApiService'
 import CognitoService from './services/CognitoService'
@@ -110,6 +110,7 @@ export class CommonNetworkMember {
   private readonly _phoneIssuer: PhoneIssuerService
   private readonly _emailIssuer: EmailIssuerService
   private _didDocumentKeyId: string
+  protected _component: EventComponent
   protected cognitoUserTokens: CognitoUserTokens
 
   constructor(password: string, encryptedSeed: string, options: SdkOptions = {}) {
@@ -1850,7 +1851,7 @@ export class CommonNetworkMember {
       metadata: metadata,
     }
 
-    this._metricsService.send(event)
+    this._metricsService.send(event, this._component)
   }
 
   /* istanbul ignore next: private method */
@@ -1864,7 +1865,7 @@ export class CommonNetworkMember {
       metadata: metadata,
     }
 
-    this._metricsService.send(event)
+    this._metricsService.send(event, this._component)
   }
 
   private _sendVCSavedMetric(vcId: string, issuerId: string, metadata: EventMetadata) {
@@ -1877,7 +1878,7 @@ export class CommonNetworkMember {
       metadata: metadata,
     }
 
-    this._metricsService.send(event)
+    this._metricsService.send(event, this._component)
   }
 
   protected _sendVCSavedMetrics(credentials: SignedCredential[]) {

--- a/sdk/core/src/index.ts
+++ b/sdk/core/src/index.ts
@@ -5,7 +5,3 @@ export { CommonNetworkMember } from './CommonNetworkMember'
 import * as __dangerous from './dangerous'
 
 export { __dangerous }
-
-import { EventComponent } from '@affinidi/affinity-metrics-lib'
-
-export { EventComponent }

--- a/sdk/core/src/index.ts
+++ b/sdk/core/src/index.ts
@@ -5,3 +5,7 @@ export { CommonNetworkMember } from './CommonNetworkMember'
 import * as __dangerous from './dangerous'
 
 export { __dangerous }
+
+import { EventComponent } from '@affinidi/affinity-metrics-lib'
+
+export { EventComponent }

--- a/sdk/core/src/services/MetricsService.ts
+++ b/sdk/core/src/services/MetricsService.ts
@@ -13,8 +13,7 @@ export default class MetricsService {
     this._metricsUrl = options.metricsUrl
   }
 
-  send(event: MetricsEvent): void {
-    const component = EventComponent.AffinityBrowserExpoSDK
+  send(event: MetricsEvent, component: EventComponent): void {
 
     const metricsEvent = Object.assign({}, event, { component })
 

--- a/sdk/core/src/services/MetricsService.ts
+++ b/sdk/core/src/services/MetricsService.ts
@@ -7,14 +7,16 @@ import { MetricsEvent, MetricsServiceOptions } from '../dto/shared.dto'
 export default class MetricsService {
   _apiKey: string
   _metricsUrl: string
+  _component: EventComponent
 
-  constructor(options: MetricsServiceOptions) {
+  constructor(options: MetricsServiceOptions, component?: EventComponent) {
     this._apiKey = options.apiKey
     this._metricsUrl = options.metricsUrl
+    this._component = component
   }
 
-  send(event: MetricsEvent, component: EventComponent): void {
-    const metricsEvent = Object.assign({}, event, { component })
+  send(event: MetricsEvent): void {
+    const metricsEvent = Object.assign({}, event, { component: this._component })
 
     metrics.send(metricsEvent, this._apiKey, this._metricsUrl)
   }

--- a/sdk/core/src/services/MetricsService.ts
+++ b/sdk/core/src/services/MetricsService.ts
@@ -14,7 +14,6 @@ export default class MetricsService {
   }
 
   send(event: MetricsEvent, component: EventComponent): void {
-
     const metricsEvent = Object.assign({}, event, { component })
 
     metrics.send(metricsEvent, this._apiKey, this._metricsUrl)

--- a/sdk/expo/package-lock.json
+++ b/sdk/expo/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@affinidi/wallet-expo-sdk",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/sdk/expo/package-lock.json
+++ b/sdk/expo/package-lock.json
@@ -4,6 +4,15 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@affinidi/affinity-metrics-lib": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@affinidi/affinity-metrics-lib/-/affinity-metrics-lib-0.0.18.tgz",
+      "integrity": "sha512-yeorbuxXdUxuT6RenyYbvO8Ifp3J9beg4oIrE77WjxNgrtSFzhiiM98rJ6j6Peegs31YGSFWrpjDTjD56GZbPA==",
+      "requires": {
+        "keccak256": "^1.0.0",
+        "node-fetch": "^2.6.0"
+      }
+    },
     "@affinidi/eslint-config": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@affinidi/eslint-config/-/eslint-config-1.0.1.tgz",
@@ -4090,6 +4099,24 @@
       "integrity": "sha512-ApcjaOdVTJ7y4r08xI5wIqpvwS48Q0PBG4DJROcEkH1f8MdAiNFyFxz3xoL0LWAVwjrwPYZdVHHxhRHcx/uGLA==",
       "dev": true
     },
+    "keccak": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.1.tgz",
+      "integrity": "sha512-epq90L9jlFWCW7+pQa6JOnKn2Xgl2mtI664seYR6MHskvI9agt7AnDqmAlp9TqU4/caMYbA08Hi5DMZAl5zdkA==",
+      "requires": {
+        "node-addon-api": "^2.0.0",
+        "node-gyp-build": "^4.2.0"
+      }
+    },
+    "keccak256": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/keccak256/-/keccak256-1.0.1.tgz",
+      "integrity": "sha512-wJM3lUBboGc5nOH3iIkFFWnnI8km0RHspLqfedDPCHvdHFVOhArGkx27KdaqOd2/gqqMUeWBThEs8iuC4mZZHQ==",
+      "requires": {
+        "bn.js": "^4.11.8",
+        "keccak": "^3.0.1"
+      }
+    },
     "kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -4865,6 +4892,11 @@
         "path-to-regexp": "^1.7.0"
       }
     },
+    "node-addon-api": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
+      "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
+    },
     "node-environment-flags": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.6.tgz",
@@ -4887,6 +4919,11 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
       "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+    },
+    "node-gyp-build": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
+      "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg=="
     },
     "node-libs-browser": {
       "version": "2.2.1",

--- a/sdk/expo/package.json
+++ b/sdk/expo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@affinidi/wallet-expo-sdk",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "SDK monorepo for affinity DID solution for Expo",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -41,7 +41,7 @@
   "license": "ISC",
   "dependencies": {
     "@affinidi/common": "1.1.2",
-    "@affinidi/wallet-core-sdk": "2.0.2",
+    "@affinidi/wallet-core-sdk": "2.0.3",
     "@react-native-community/netinfo": "^5.5.1",
     "@types/text-encoding": "0.0.35",
     "assert": "^2.0.0",

--- a/sdk/expo/package.json
+++ b/sdk/expo/package.json
@@ -42,6 +42,7 @@
   "dependencies": {
     "@affinidi/common": "1.1.2",
     "@affinidi/wallet-core-sdk": "2.0.3",
+    "@affinidi/affinity-metrics-lib": "0.0.18",
     "@react-native-community/netinfo": "^5.5.1",
     "@types/text-encoding": "0.0.35",
     "assert": "^2.0.0",

--- a/sdk/expo/src/AffinityWallet.ts
+++ b/sdk/expo/src/AffinityWallet.ts
@@ -1,4 +1,5 @@
-import { CommonNetworkMember as CoreNetwork, __dangerous, EventComponent } from '@affinidi/wallet-core-sdk'
+import { CommonNetworkMember as CoreNetwork, __dangerous } from '@affinidi/wallet-core-sdk'
+import { EventComponent } from '@affinidi/affinity-metrics-lib'
 
 import KeysService from './services/KeysService'
 import WalletStorageService from './services/WalletStorageService'

--- a/sdk/expo/src/AffinityWallet.ts
+++ b/sdk/expo/src/AffinityWallet.ts
@@ -1,4 +1,4 @@
-import { CommonNetworkMember as CoreNetwork, __dangerous } from '@affinidi/wallet-core-sdk'
+import { CommonNetworkMember as CoreNetwork, __dangerous, EventComponent } from '@affinidi/wallet-core-sdk'
 
 import KeysService from './services/KeysService'
 import WalletStorageService from './services/WalletStorageService'
@@ -23,6 +23,7 @@ export class AffinityWallet extends CoreNetwork {
 
     this.keysService = new KeysService(encryptedSeed, password)
     this.walletStorageService = new WalletStorageService(encryptedSeed, password, sdkOptions)
+    this._component = EventComponent.AffinidiExpoSDK
   }
 
   set skipBackupCredentials(value: boolean) {

--- a/sdk/expo/src/AffinityWallet.ts
+++ b/sdk/expo/src/AffinityWallet.ts
@@ -8,6 +8,9 @@ import { profile } from '@affinidi/common'
 type SdkOptions = __dangerous.SdkOptions & {
   issueSignupCredential?: boolean
 }
+
+const COMPONENT = EventComponent.AffinidiExpoSDK
+
 @profile()
 export class AffinityWallet extends CoreNetwork {
   _skipBackupCredentials: boolean = false
@@ -15,8 +18,13 @@ export class AffinityWallet extends CoreNetwork {
   keysService: KeysService
   walletStorageService: WalletStorageService
 
-  constructor(password: string, encryptedSeed: string, options: __dangerous.SdkOptions = {}) {
-    super(password, encryptedSeed, options)
+  constructor(
+    password: string,
+    encryptedSeed: string,
+    options: __dangerous.SdkOptions = {},
+    component: EventComponent = COMPONENT,
+  ) {
+    super(password, encryptedSeed, options, component)
 
     const sdkOptions = CoreNetwork.setEnvironmentVarialbles(options)
 
@@ -24,7 +32,6 @@ export class AffinityWallet extends CoreNetwork {
 
     this.keysService = new KeysService(encryptedSeed, password)
     this.walletStorageService = new WalletStorageService(encryptedSeed, password, sdkOptions)
-    this._component = EventComponent.AffinidiExpoSDK
   }
 
   set skipBackupCredentials(value: boolean) {

--- a/sdk/react-native/package-lock.json
+++ b/sdk/react-native/package-lock.json
@@ -1,94 +1,9 @@
 {
 	"name": "@affinidi/wallet-react-native-sdk",
-	"version": "2.0.1",
+	"version": "2.0.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
-		"@affinidi/affinity-metrics-lib": {
-			"version": "0.0.12",
-			"resolved": "https://registry.npmjs.org/@affinidi/affinity-metrics-lib/-/affinity-metrics-lib-0.0.12.tgz",
-			"integrity": "sha512-uG3WZH8OLV8rxtqiq/3T2ZlCsS7CPsMvcPSRhIteZKdLhKxF8pN/27PPl9HWyTjhB2dnYHwbX3h8LQJqCCo2gg==",
-			"requires": {
-				"keccak256": "^1.0.0",
-				"node-fetch": "^2.6.0"
-			}
-		},
-		"@affinidi/common": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@affinidi/common/-/common-1.1.2.tgz",
-			"integrity": "sha512-NwzyQnOx9yMs3aUBJ15yd1QPvHfxf2pYveYq2vpN2sAwRq+Z/L++zoKXZ47wZIdaoq73VEEC+xasPWxM9HNStQ==",
-			"requires": {
-				"@affinidi/tiny-lds-ecdsa-secp256k1-2019": "^1.0.1",
-				"@affinidi/vc-common": "1.1.1",
-				"@types/create-hash": "^1.2.2",
-				"@types/jsonld": "^1.5.1",
-				"@types/lodash.keyby": "^4.6.6",
-				"@types/node-fetch": "^2.5.4",
-				"@types/secp256k1": "^4.0.1",
-				"@types/tiny-secp256k1": "^1.0.0",
-				"@types/zen-observable": "^0.8.0",
-				"base64url": "^3.0.1",
-				"bip32": "^2.0.5",
-				"browserify-aes": "^1.2.0",
-				"create-hash": "^1.2.0",
-				"did-resolver": "^2.0.1",
-				"ethereumjs-util": "^5.0.0",
-				"jsonld": "^2.0.2",
-				"jsontokens": "^3.0.0",
-				"keccak256": "^1.0.0",
-				"lodash.keyby": "^4.6.0",
-				"multihashes": "^3.0.0",
-				"node-addon-api": "^3.0.0",
-				"node-fetch": "^2.6.0",
-				"randombytes": "^2.1.0",
-				"secp256k1": "^4.0.1",
-				"tiny-secp256k1": "^1.1.5",
-				"tslib": "^2.0.0",
-				"vc-revocation-list": "^2.0.0"
-			},
-			"dependencies": {
-				"jsonld": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/jsonld/-/jsonld-2.0.2.tgz",
-					"integrity": "sha512-/TQzRe75/3h2khu57IUojha5oat+M82bm8RYw0jLhlmmPrW/kTWAZ9nGzKPfZWnPYnVVJJMQVc/pU8HCmpv9xg==",
-					"requires": {
-						"canonicalize": "^1.0.1",
-						"lru-cache": "^5.1.1",
-						"rdf-canonize": "^1.0.2",
-						"request": "^2.88.0",
-						"semver": "^6.3.0",
-						"xmldom": "0.1.19"
-					}
-				},
-				"node-addon-api": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.0.2.tgz",
-					"integrity": "sha512-+D4s2HCnxPd5PjjI0STKwncjXTUKKqm74MDMz9OPXavjsGmjkvwgLtA5yoxJUdmpj52+2u+RrXgPipahKczMKg=="
-				},
-				"secp256k1": {
-					"version": "4.0.2",
-					"resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.2.tgz",
-					"integrity": "sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==",
-					"requires": {
-						"elliptic": "^6.5.2",
-						"node-addon-api": "^2.0.0",
-						"node-gyp-build": "^4.2.0"
-					},
-					"dependencies": {
-						"node-addon-api": {
-							"version": "2.0.2",
-							"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
-							"integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
-						}
-					}
-				},
-				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-				}
-			}
-		},
 		"@affinidi/eslint-config": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@affinidi/eslint-config/-/eslint-config-1.0.1.tgz",
@@ -100,181 +15,6 @@
 			"resolved": "https://registry.npmjs.org/@affinidi/prettier-config/-/prettier-config-1.0.1.tgz",
 			"integrity": "sha512-gfyv27MdiqUFyCTBWY3SWJAbYm2aclg+7uqlUfVYoXMKwGpb/YkWwfqAgIzq6F3nLL4DjJIG1eln2XL/BDaIdA==",
 			"dev": true
-		},
-		"@affinidi/tiny-lds-ecdsa-secp256k1-2019": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@affinidi/tiny-lds-ecdsa-secp256k1-2019/-/tiny-lds-ecdsa-secp256k1-2019-1.0.1.tgz",
-			"integrity": "sha512-jd1gPO4VBWvVbYkL0VdahAqWAizFxH9D+2mzaerqad4MCcvIRkcOkd4ihpmBQtTOaUFNxAaRa6ioysqWbBMWmA==",
-			"requires": {
-				"@types/create-hash": "^1.2.2",
-				"@types/tiny-secp256k1": "^1.0.0",
-				"base64url": "^3.0.1",
-				"create-hash": "^1.2.0",
-				"jsonld": "^2.0.2",
-				"jsonld-signatures": "^5.1.0",
-				"tiny-secp256k1": "^1.1.5",
-				"tslib": "^2.0.1"
-			},
-			"dependencies": {
-				"jsonld": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/jsonld/-/jsonld-2.0.2.tgz",
-					"integrity": "sha512-/TQzRe75/3h2khu57IUojha5oat+M82bm8RYw0jLhlmmPrW/kTWAZ9nGzKPfZWnPYnVVJJMQVc/pU8HCmpv9xg==",
-					"requires": {
-						"canonicalize": "^1.0.1",
-						"lru-cache": "^5.1.1",
-						"rdf-canonize": "^1.0.2",
-						"request": "^2.88.0",
-						"semver": "^6.3.0",
-						"xmldom": "0.1.19"
-					}
-				},
-				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-				}
-			}
-		},
-		"@affinidi/vc-common": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@affinidi/vc-common/-/vc-common-1.1.1.tgz",
-			"integrity": "sha512-cJc6Y0awfaRGoMKqog4pVqltEMdfoIFvR+R4NEbf/IvcG6nVTZE4uVOhXNKbk9bfT7Snr9nc9+6WOpRRiSihKg==",
-			"requires": {
-				"did-resolver": "2.0.1",
-				"jsonld": "^2.0.2",
-				"jsonld-signatures": "^5.1.0",
-				"tiny-warning": "^1.0.3",
-				"tslib": "^2.0.1"
-			},
-			"dependencies": {
-				"did-resolver": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/did-resolver/-/did-resolver-2.0.1.tgz",
-					"integrity": "sha512-NomJQaRiu0izKFFerYGrca48YxWtMOtOoqG3JUTLJtET8n2T1i8WlQz500zesnioZWi5RVNsUS/eMQfRWy7bbg=="
-				},
-				"jsonld": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/jsonld/-/jsonld-2.0.2.tgz",
-					"integrity": "sha512-/TQzRe75/3h2khu57IUojha5oat+M82bm8RYw0jLhlmmPrW/kTWAZ9nGzKPfZWnPYnVVJJMQVc/pU8HCmpv9xg==",
-					"requires": {
-						"canonicalize": "^1.0.1",
-						"lru-cache": "^5.1.1",
-						"rdf-canonize": "^1.0.2",
-						"request": "^2.88.0",
-						"semver": "^6.3.0",
-						"xmldom": "0.1.19"
-					}
-				},
-				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-				}
-			}
-		},
-		"@affinidi/vc-data": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@affinidi/vc-data/-/vc-data-1.1.1.tgz",
-			"integrity": "sha512-RNzNbQZRp6wGSx3P0qkXJJTEP+YWj7QEWu94OIlfoyti+4e86+6R9bve0pfmwMuA4JTpCSQTFcaxIlgKVDofTA==",
-			"requires": {
-				"@affinidi/vc-common": "^1.1.1",
-				"@ahryman40k/ts-fhir-types": "^4.0.29",
-				"ts-toolbelt": "^6.4.2",
-				"tslib": "^2.0.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-				}
-			}
-		},
-		"@affinidi/wallet-core-sdk": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@affinidi/wallet-core-sdk/-/wallet-core-sdk-2.0.1.tgz",
-			"integrity": "sha512-Dw2q3vK51ScztjAKBIzCDmQ6mbfIgU+99omTyOnjqC5zxTAmqO12mE/EHFaa8Aii3n/OJAiwqxH5FVTjfnT1GQ==",
-			"requires": {
-				"@affinidi/affinity-metrics-lib": "0.0.12",
-				"@affinidi/common": "1.1.2",
-				"@affinidi/vc-common": "1.1.1",
-				"@affinidi/vc-data": "^1.1.1",
-				"@affinityproject/issuer-email-ses-client": "^0.1.0",
-				"@affinityproject/issuer-phone-twilio-client": "^0.1.0",
-				"@types/async-retry": "^1.4.2",
-				"@types/create-hash": "^1.2.2",
-				"@types/jsonld": "^1.5.1",
-				"@types/lodash.keyby": "^4.6.6",
-				"@types/node-fetch": "^2.5.4",
-				"@types/zen-observable": "^0.8.0",
-				"ajv": "^6.12.3",
-				"async-retry": "^1.3.1",
-				"aws-sdk": "^2.721.0",
-				"base64url": "^3.0.1",
-				"bip32": "^2.0.5",
-				"browserify-aes": "^1.2.0",
-				"class-validator": "^0.12.0",
-				"create-hash": "^1.2.0",
-				"did-resolver": "^2.0.1",
-				"ethereumjs-util": "^5.0.0",
-				"fluent-schema": "^1.0.4",
-				"jsonld": "^3.0.0",
-				"jsontokens": "^3.0.0",
-				"keccak256": "^1.0.0",
-				"lodash.keyby": "^4.6.0",
-				"lodash.uniq": "^4.5.0",
-				"multihashes": "^3.0.0",
-				"node-fetch": "^2.6.0",
-				"randombytes": "^2.1.0",
-				"secp256k1": "^4.0.0",
-				"tslib": "^2.0.0"
-			},
-			"dependencies": {
-				"secp256k1": {
-					"version": "4.0.2",
-					"resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.2.tgz",
-					"integrity": "sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==",
-					"requires": {
-						"elliptic": "^6.5.2",
-						"node-addon-api": "^2.0.0",
-						"node-gyp-build": "^4.2.0"
-					}
-				},
-				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-				}
-			}
-		},
-		"@affinityproject/issuer-email-ses-client": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/@affinityproject/issuer-email-ses-client/-/issuer-email-ses-client-0.1.0.tgz",
-			"integrity": "sha512-yd2A1INx5+Xp7RmVy7mPgzkPK/IbXmlbS9M1HmbQGK4M4iblJFnE7LhsP4SYpkFryDHHy55GKsmtcf8Ec7iJwQ==",
-			"requires": {
-				"@types/axios": "^0.14.0",
-				"axios": "^0.19.2"
-			}
-		},
-		"@affinityproject/issuer-phone-twilio-client": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/@affinityproject/issuer-phone-twilio-client/-/issuer-phone-twilio-client-0.1.0.tgz",
-			"integrity": "sha512-Qn4pX1cdAqp2ff6Yz1eDdA61TyI/N/WwhITRx4qAuwT2fVwRrsw6+DvczcPxvC6hhIUR7IQ39p0BlVLual5NHw==",
-			"requires": {
-				"@types/axios": "^0.14.0",
-				"axios": "^0.19.2"
-			}
-		},
-		"@ahryman40k/ts-fhir-types": {
-			"version": "4.0.34",
-			"resolved": "https://registry.npmjs.org/@ahryman40k/ts-fhir-types/-/ts-fhir-types-4.0.34.tgz",
-			"integrity": "sha512-G/o0wmYoqOfvgSids46U6ge767OjQfNkr8lUcqblZsLpOZF/xiXE46eXmfmnxzjYD2FvlpUQM4LxmK4f0feWkA==",
-			"requires": {
-				"fp-ts": "^2.8.3",
-				"io-ts": "^2.0.0",
-				"reflect-metadata": "^0.1.13"
-			}
 		},
 		"@babel/code-frame": {
 			"version": "7.10.4",
@@ -516,16 +256,6 @@
 				"to-fast-properties": "^2.0.0"
 			}
 		},
-		"@digitalbazaar/bitstring": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@digitalbazaar/bitstring/-/bitstring-1.2.0.tgz",
-			"integrity": "sha512-l+/LPBeikkIorRXTwRgzbnE09cMzV1MXNc52kFw4guIQy30MPAdoj8i+ajvyv/2saCnebXgM4jsDXlJSseGV7A==",
-			"requires": {
-				"base64url-universal": "^1.1.0",
-				"esm": "^3.2.25",
-				"pako": "^1.0.11"
-			}
-		},
 		"@istanbuljs/load-nyc-config": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -598,11 +328,6 @@
 			"resolved": "https://registry.npmjs.org/@kravc/request/-/request-1.0.0.tgz",
 			"integrity": "sha512-i78TYI30PNycmvXDlXVvn0npYxPuHxf5Mn++/Y5gFdA4LFGArfY5nWWggNV4dx9n1fWw7iBnzz0030UuO37Kyg==",
 			"dev": true
-		},
-		"@multiformats/base-x": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@multiformats/base-x/-/base-x-4.0.1.tgz",
-			"integrity": "sha512-eMk0b9ReBbV23xXU693TAIrLyeO5iTgBZGSJfpqriG8UkYvr/hC9u9pyMlAakDNHWmbhMZCDs6KQO0jzKD8OTw=="
 		},
 		"@react-native-community/netinfo": {
 			"version": "5.9.5",
@@ -778,26 +503,11 @@
 			"integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
 			"dev": true
 		},
-		"@types/async-retry": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/@types/async-retry/-/async-retry-1.4.2.tgz",
-			"integrity": "sha512-GUDuJURF0YiJZ+CBjNQA0+vbP/VHlJbB0sFqkzsV7EcOPRfurVonXpXKAt3w8qIjM1TEzpz6hc6POocPvHOS3w==",
-			"requires": {
-				"@types/retry": "*"
-			}
-		},
-		"@types/axios": {
-			"version": "0.14.0",
-			"resolved": "https://registry.npmjs.org/@types/axios/-/axios-0.14.0.tgz",
-			"integrity": "sha1-7CMA++fX3d1+udOr+HmZlkyvzkY=",
-			"requires": {
-				"axios": "*"
-			}
-		},
 		"@types/bn.js": {
 			"version": "4.11.6",
 			"resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
 			"integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
+			"dev": true,
 			"requires": {
 				"@types/node": "*"
 			},
@@ -805,7 +515,8 @@
 				"@types/node": {
 					"version": "14.0.27",
 					"resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.27.tgz",
-					"integrity": "sha512-kVrqXhbclHNHGu9ztnAwSncIgJv/FaxmzXJvGXNdcCpV1b8u1/Mi6z6m0vwy0LzKeXFTPLH0NzwmoJ3fNCIq0g=="
+					"integrity": "sha512-kVrqXhbclHNHGu9ztnAwSncIgJv/FaxmzXJvGXNdcCpV1b8u1/Mi6z6m0vwy0LzKeXFTPLH0NzwmoJ3fNCIq0g==",
+					"dev": true
 				}
 			}
 		},
@@ -838,22 +549,6 @@
 			"dev": true,
 			"requires": {
 				"@types/node": "*"
-			}
-		},
-		"@types/create-hash": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@types/create-hash/-/create-hash-1.2.2.tgz",
-			"integrity": "sha512-Fg8/kfMJObbETFU/Tn+Y0jieYewryLrbKwLCEIwPyklZZVY2qB+64KFjhplGSw+cseZosfFXctXO+PyIYD8iZQ==",
-			"requires": {
-				"@types/node": "*"
-			}
-		},
-		"@types/elliptic": {
-			"version": "6.4.12",
-			"resolved": "https://registry.npmjs.org/@types/elliptic/-/elliptic-6.4.12.tgz",
-			"integrity": "sha512-gP1KsqoouLJGH6IJa28x7PXb3cRqh83X8HCLezd2dF+XcAIMKYv53KV+9Zn6QA561E120uOqZBQ+Jy/cl+fviw==",
-			"requires": {
-				"@types/bn.js": "*"
 			}
 		},
 		"@types/eslint-visitor-keys": {
@@ -901,24 +596,6 @@
 			"integrity": "sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==",
 			"dev": true
 		},
-		"@types/jsonld": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/@types/jsonld/-/jsonld-1.5.1.tgz",
-			"integrity": "sha512-8XI88iiCBVqmNCMBqPOgJhJPPuiIW1Tp2sXqe3NwD137ljhQVkDWY8cuYBBDZQoBYfGzUJvja527bbwqVbRnHQ=="
-		},
-		"@types/lodash": {
-			"version": "4.14.162",
-			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.162.tgz",
-			"integrity": "sha512-alvcho1kRUnnD1Gcl4J+hK0eencvzq9rmzvFPRmP5rPHx9VVsJj6bKLTATPVf9ktgv4ujzh7T+XWKp+jhuODig=="
-		},
-		"@types/lodash.keyby": {
-			"version": "4.6.6",
-			"resolved": "https://registry.npmjs.org/@types/lodash.keyby/-/lodash.keyby-4.6.6.tgz",
-			"integrity": "sha512-4Y6+lMFnMfB6FZoZbX4VB2puzIMDe0wDxMoxlOx4bNASAAgx3PtINs6+mcOUQzvljgFjy3GylRyZeCW6C2DwOQ==",
-			"requires": {
-				"@types/lodash": "*"
-			}
-		},
 		"@types/mime": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.3.tgz",
@@ -940,36 +617,8 @@
 		"@types/node": {
 			"version": "13.13.15",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.15.tgz",
-			"integrity": "sha512-kwbcs0jySLxzLsa2nWUAGOd/s21WU1jebrEdtzhsj1D4Yps1EOuyI1Qcu+FD56dL7NRNIJtDDjcqIG22NwkgLw=="
-		},
-		"@types/node-fetch": {
-			"version": "2.5.7",
-			"resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.7.tgz",
-			"integrity": "sha512-o2WVNf5UhWRkxlf6eq+jMZDu7kjgpgJfl4xVNlvryc95O/6F2ld8ztKX+qu+Rjyet93WAWm5LjeX9H5FGkODvw==",
-			"requires": {
-				"@types/node": "*",
-				"form-data": "^3.0.0"
-			},
-			"dependencies": {
-				"form-data": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
-					"integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
-					"requires": {
-						"asynckit": "^0.4.0",
-						"combined-stream": "^1.0.8",
-						"mime-types": "^2.1.12"
-					}
-				}
-			}
-		},
-		"@types/pbkdf2": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/@types/pbkdf2/-/pbkdf2-3.1.0.tgz",
-			"integrity": "sha512-Cf63Rv7jCQ0LaL8tNXmEyqTHuIJxRdlS5vMh1mj5voN4+QFhVZnlZruezqpWYDiJ8UTzhP0VmeLXCmBk66YrMQ==",
-			"requires": {
-				"@types/node": "*"
-			}
+			"integrity": "sha512-kwbcs0jySLxzLsa2nWUAGOd/s21WU1jebrEdtzhsj1D4Yps1EOuyI1Qcu+FD56dL7NRNIJtDDjcqIG22NwkgLw==",
+			"dev": true
 		},
 		"@types/prop-types": {
 			"version": "15.7.3",
@@ -1006,19 +655,6 @@
 			"requires": {
 				"@types/prop-types": "*",
 				"csstype": "^3.0.2"
-			}
-		},
-		"@types/retry": {
-			"version": "0.12.0",
-			"resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
-			"integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="
-		},
-		"@types/secp256k1": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@types/secp256k1/-/secp256k1-4.0.1.tgz",
-			"integrity": "sha512-+ZjSA8ELlOp8SlKi0YLB2tz9d5iPNEmOBd+8Rz21wTMdaXQIa9b6TEnD6l5qKOCypE7FSyPyck12qZJxSDNoog==",
-			"requires": {
-				"@types/node": "*"
 			}
 		},
 		"@types/serve-static": {
@@ -1060,24 +696,6 @@
 			"version": "0.0.35",
 			"resolved": "https://registry.npmjs.org/@types/text-encoding/-/text-encoding-0.0.35.tgz",
 			"integrity": "sha512-jfo/A88XIiAweUa8np+1mPbm3h2w0s425YrI8t3wk5QxhH6UI7w517MboNVnGDeMSuoFwA8Rwmklno+FicvV4g=="
-		},
-		"@types/tiny-secp256k1": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@types/tiny-secp256k1/-/tiny-secp256k1-1.0.0.tgz",
-			"integrity": "sha512-IW3dFGNyVkVLC1MCMogVWQaKH/ZtjPQdOW9c3X128o5lVpFYNsq/l3Qo1pV7sfTmvDzWEXR3QTxg1TMy1pyaAQ==",
-			"requires": {
-				"@types/node": "*"
-			}
-		},
-		"@types/validator": {
-			"version": "13.0.0",
-			"resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.0.0.tgz",
-			"integrity": "sha512-WAy5txG7aFX8Vw3sloEKp5p/t/Xt8jD3GRD9DacnFv6Vo8ubudAsRTXgxpQwU0mpzY/H8U4db3roDuCMjShBmw=="
-		},
-		"@types/zen-observable": {
-			"version": "0.8.1",
-			"resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.1.tgz",
-			"integrity": "sha512-wmk0xQI6Yy7Fs/il4EpOcflG4uonUpYGqvZARESLc2oy4u69fkatFLbJOeW4Q6awO15P4rduAe6xkwHevpXcUQ=="
 		},
 		"@typescript-eslint/eslint-plugin": {
 			"version": "3.8.0",
@@ -1398,6 +1016,7 @@
 			"version": "6.12.3",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.3.tgz",
 			"integrity": "sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==",
+			"dev": true,
 			"requires": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -1528,25 +1147,6 @@
 			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
 			"dev": true
 		},
-		"asn1": {
-			"version": "0.2.4",
-			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-			"integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
-			"requires": {
-				"safer-buffer": "~2.1.0"
-			}
-		},
-		"asn1.js": {
-			"version": "5.4.1",
-			"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
-			"integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
-			"requires": {
-				"bn.js": "^4.0.0",
-				"inherits": "^2.0.1",
-				"minimalistic-assert": "^1.0.0",
-				"safer-buffer": "^2.1.0"
-			}
-		},
 		"assert": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/assert/-/assert-2.0.0.tgz",
@@ -1557,11 +1157,6 @@
 				"object-is": "^1.0.1",
 				"util": "^0.12.0"
 			}
-		},
-		"assert-plus": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
 		},
 		"assertion-error": {
 			"version": "1.1.0",
@@ -1588,19 +1183,6 @@
 			"dev": true,
 			"optional": true
 		},
-		"async-retry": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.1.tgz",
-			"integrity": "sha512-aiieFW/7h3hY0Bq5d+ktDBejxuwR78vRu9hDUdR8rNhSaQ29VzPL4AoIRG7D/c7tdenwOcKvgPM6tIxB3cB6HA==",
-			"requires": {
-				"retry": "0.12.0"
-			}
-		},
-		"asynckit": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-		},
 		"atob": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
@@ -1613,62 +1195,6 @@
 			"integrity": "sha512-XWX3OX8Onv97LMk/ftVyBibpGwY5a8SmuxZPzeOxqmuEqUCOM9ZE+uIaD1VNJ5QnvU2UQusvmKbuM1FR8QWGfQ==",
 			"requires": {
 				"array-filter": "^1.0.0"
-			}
-		},
-		"aws-sdk": {
-			"version": "2.778.0",
-			"resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.778.0.tgz",
-			"integrity": "sha512-sIJRO7tMaztLs+gvHF/Wo+iek/rhH99+2OzharQJMS0HATPl5/EdhKgWGv1n/bNpVH+kD3n0QMQgdFu0FNUt0Q==",
-			"requires": {
-				"buffer": "4.9.2",
-				"events": "1.1.1",
-				"ieee754": "1.1.13",
-				"jmespath": "0.15.0",
-				"querystring": "0.2.0",
-				"sax": "1.2.1",
-				"url": "0.10.3",
-				"uuid": "3.3.2",
-				"xml2js": "0.4.19"
-			},
-			"dependencies": {
-				"buffer": {
-					"version": "4.9.2",
-					"resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
-					"integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
-					"requires": {
-						"base64-js": "^1.0.2",
-						"ieee754": "^1.1.4",
-						"isarray": "^1.0.0"
-					}
-				},
-				"events": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
-					"integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
-				},
-				"uuid": {
-					"version": "3.3.2",
-					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-					"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
-				}
-			}
-		},
-		"aws-sign2": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
-		},
-		"aws4": {
-			"version": "1.10.1",
-			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.1.tgz",
-			"integrity": "sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA=="
-		},
-		"axios": {
-			"version": "0.19.2",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
-			"integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
-			"requires": {
-				"follow-redirects": "1.5.10"
 			}
 		},
 		"backbone": {
@@ -1753,27 +1279,6 @@
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
 			"integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
 		},
-		"base64url": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
-			"integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A=="
-		},
-		"base64url-universal": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/base64url-universal/-/base64url-universal-1.1.0.tgz",
-			"integrity": "sha512-WyftvZqye29YQ10ZnuiBeEj0lk8SN8xHU9hOznkLc85wS1cLTp6RpzlMrHxMPD9nH7S55gsBqMqgGyz93rqmkA==",
-			"requires": {
-				"base64url": "^3.0.0"
-			}
-		},
-		"bcrypt-pbkdf": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-			"integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-			"requires": {
-				"tweetnacl": "^0.14.3"
-			}
-		},
 		"big-integer": {
 			"version": "1.6.48",
 			"resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.48.tgz",
@@ -1827,11 +1332,6 @@
 			"requires": {
 				"safe-buffer": "^5.0.1"
 			}
-		},
-		"blakejs": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.1.0.tgz",
-			"integrity": "sha1-ad+S75U6qIylGjLfarHFShVfx6U="
 		},
 		"bluebird": {
 			"version": "3.7.2",
@@ -2074,11 +1574,6 @@
 			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
 			"integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA=="
 		},
-		"canonicalize": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-1.0.3.tgz",
-			"integrity": "sha512-QWAGweNicWIXzcl7skvUZQ/ArdecS8fOeudnjIU0LYqSdTOSBSap+0VPMas4u11cW3a9sN5AN/aJHQUGfdWLCw=="
-		},
 		"caseless": {
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
@@ -2197,17 +1692,6 @@
 				}
 			}
 		},
-		"class-validator": {
-			"version": "0.12.2",
-			"resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.12.2.tgz",
-			"integrity": "sha512-TDzPzp8BmpsbPhQpccB3jMUE/3pK0TyqamrK0kcx+ZeFytMA+O6q87JZZGObHHnoo9GM8vl/JppIyKWeEA/EVw==",
-			"requires": {
-				"@types/validator": "13.0.0",
-				"google-libphonenumber": "^3.2.8",
-				"tslib": ">=1.9.0",
-				"validator": "13.0.0"
-			}
-		},
 		"clean-stack": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
@@ -2275,18 +1759,11 @@
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 		},
-		"combined-stream": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-			"requires": {
-				"delayed-stream": "~1.0.0"
-			}
-		},
 		"commander": {
 			"version": "2.20.3",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+			"dev": true
 		},
 		"commondir": {
 			"version": "1.0.1",
@@ -2415,7 +1892,8 @@
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+			"dev": true
 		},
 		"create-ecdh": {
 			"version": "4.0.4",
@@ -2450,11 +1928,6 @@
 				"safe-buffer": "^5.0.1",
 				"sha.js": "^2.4.8"
 			}
-		},
-		"credentials-context": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/credentials-context/-/credentials-context-1.0.0.tgz",
-			"integrity": "sha512-rF3GPhTUGY58xlpuVRif/1i0BxVpynpmFdGNS81S2ezdKPSKoFke5ZOZWB8ZUvGi8bV8CuDM+ZcM/uf4z0PQVQ=="
 		},
 		"cross-spawn": {
 			"version": "6.0.5",
@@ -2494,18 +1967,6 @@
 				"randomfill": "^1.0.3"
 			}
 		},
-		"crypto-ld": {
-			"version": "3.9.0",
-			"resolved": "https://registry.npmjs.org/crypto-ld/-/crypto-ld-3.9.0.tgz",
-			"integrity": "sha512-PFE7V6A2QNnUp6iiPVEZI4p8wsztkEWLbY1BAXVnclm/aw4KGwpJ+1Ds4vQUCJ5BsWxj15fwE5rHQ8AWaWB2nw==",
-			"requires": {
-				"base64url-universal": "^1.0.1",
-				"bs58": "^4.0.1",
-				"node-forge": "~0.10.0",
-				"semver": "^6.2.0",
-				"sodium-native": "^3.2.0"
-			}
-		},
 		"crypto-random-string": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-3.3.0.tgz",
@@ -2526,14 +1987,6 @@
 			"resolved": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz",
 			"integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=",
 			"dev": true
-		},
-		"dashdash": {
-			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-			"requires": {
-				"assert-plus": "^1.0.0"
-			}
 		},
 		"debug": {
 			"version": "4.1.1",
@@ -2574,11 +2027,6 @@
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
 			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
 			"dev": true
-		},
-		"deepmerge": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
-			"integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
 		},
 		"default-require-extensions": {
 			"version": "3.0.0",
@@ -2638,11 +2086,6 @@
 				}
 			}
 		},
-		"delayed-stream": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
-		},
 		"des.js": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
@@ -2667,11 +2110,6 @@
 				"asap": "^2.0.0",
 				"wrappy": "1"
 			}
-		},
-		"did-resolver": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/did-resolver/-/did-resolver-2.1.1.tgz",
-			"integrity": "sha512-FYLTkNWofjYNDGV1HTQlyVu1OqZiFxR4I8KM+oxGVOkbXva15NfWzbzciqdXUDqOhe6so5aroAdrVip6gSAYSA=="
 		},
 		"diff": {
 			"version": "3.5.0",
@@ -2764,15 +2202,6 @@
 				}
 			}
 		},
-		"ecc-jsbn": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-			"integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-			"requires": {
-				"jsbn": "~0.1.0",
-				"safer-buffer": "^2.1.0"
-			}
-		},
 		"eccrypto-js": {
 			"version": "5.3.0",
 			"resolved": "https://registry.npmjs.org/eccrypto-js/-/eccrypto-js-5.3.0.tgz",
@@ -2785,14 +2214,6 @@
 				"pbkdf2": "^3.0.17",
 				"randombytes": "2.1.0",
 				"secp256k1": "3.8.0"
-			}
-		},
-		"ecdsa-sig-formatter": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
-			"integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
-			"requires": {
-				"safe-buffer": "^5.0.1"
 			}
 		},
 		"elliptic": {
@@ -3155,11 +2576,6 @@
 			"integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
 			"dev": true
 		},
-		"esm": {
-			"version": "3.2.25",
-			"resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
-			"integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
-		},
 		"espree": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/espree/-/espree-7.2.0.tgz",
@@ -3214,63 +2630,6 @@
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
 			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
 			"dev": true
-		},
-		"ethereum-cryptography": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
-			"integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
-			"requires": {
-				"@types/pbkdf2": "^3.0.0",
-				"@types/secp256k1": "^4.0.1",
-				"blakejs": "^1.1.0",
-				"browserify-aes": "^1.2.0",
-				"bs58check": "^2.1.2",
-				"create-hash": "^1.2.0",
-				"create-hmac": "^1.1.7",
-				"hash.js": "^1.1.7",
-				"keccak": "^3.0.0",
-				"pbkdf2": "^3.0.17",
-				"randombytes": "^2.1.0",
-				"safe-buffer": "^5.1.2",
-				"scrypt-js": "^3.0.0",
-				"secp256k1": "^4.0.1",
-				"setimmediate": "^1.0.5"
-			},
-			"dependencies": {
-				"secp256k1": {
-					"version": "4.0.2",
-					"resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.2.tgz",
-					"integrity": "sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==",
-					"requires": {
-						"elliptic": "^6.5.2",
-						"node-addon-api": "^2.0.0",
-						"node-gyp-build": "^4.2.0"
-					}
-				}
-			}
-		},
-		"ethereumjs-util": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
-			"integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
-			"requires": {
-				"bn.js": "^4.11.0",
-				"create-hash": "^1.1.2",
-				"elliptic": "^6.5.2",
-				"ethereum-cryptography": "^0.1.3",
-				"ethjs-util": "^0.1.3",
-				"rlp": "^2.0.0",
-				"safe-buffer": "^5.1.1"
-			}
-		},
-		"ethjs-util": {
-			"version": "0.1.6",
-			"resolved": "https://registry.npmjs.org/ethjs-util/-/ethjs-util-0.1.6.tgz",
-			"integrity": "sha512-CUnVOQq7gSpDHZVVrQW8ExxUETWrnrvXYvYz55wOU8Uj4VCgw56XC2B/fVqQN+f7gmrnRHSLVnFAwsCuNwji8w==",
-			"requires": {
-				"is-hex-prefixed": "1.0.0",
-				"strip-hex-prefix": "1.0.0"
-			}
 		},
 		"events": {
 			"version": "3.2.0",
@@ -3358,11 +2717,6 @@
 			"requires": {
 				"homedir-polyfill": "^1.0.1"
 			}
-		},
-		"extend": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
 		},
 		"extend-shallow": {
 			"version": "3.0.2",
@@ -3460,11 +2814,6 @@
 				}
 			}
 		},
-		"extsprintf": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
-		},
 		"fast-base64-decode": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fast-base64-decode/-/fast-base64-decode-1.0.0.tgz",
@@ -3473,7 +2822,8 @@
 		"fast-deep-equal": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+			"dev": true
 		},
 		"fast-diff": {
 			"version": "1.2.0",
@@ -3484,7 +2834,8 @@
 		"fast-json-stable-stringify": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+			"dev": true
 		},
 		"fast-levenshtein": {
 			"version": "2.0.6",
@@ -3597,14 +2948,6 @@
 			"integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
 			"dev": true
 		},
-		"fluent-schema": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/fluent-schema/-/fluent-schema-1.0.4.tgz",
-			"integrity": "sha512-osWtVf3awozl2nGGZhQbNS4GQ46HStoroNgXZ7ZZ8SICOy/eS+8PMYfNhV7PdqUSARZQ4dseCGzKkcaV+oCmjA==",
-			"requires": {
-				"deepmerge": "^4.2.2"
-			}
-		},
 		"flush-write-stream": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
@@ -3644,29 +2987,6 @@
 					"requires": {
 						"safe-buffer": "~5.1.0"
 					}
-				}
-			}
-		},
-		"follow-redirects": {
-			"version": "1.5.10",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-			"integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-			"requires": {
-				"debug": "=3.1.0"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 				}
 			}
 		},
@@ -3734,26 +3054,6 @@
 				}
 			}
 		},
-		"forever-agent": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
-		},
-		"form-data": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-			"integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-			"requires": {
-				"asynckit": "^0.4.0",
-				"combined-stream": "^1.0.6",
-				"mime-types": "^2.1.12"
-			}
-		},
-		"fp-ts": {
-			"version": "2.8.4",
-			"resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.8.4.tgz",
-			"integrity": "sha512-J+kwce5SysU0YKuZ3aCnFk+dyezZD1mij6u26w1fCVfuLYgJR4eeXmVfJiUjthpZ+4yCRkRfcwMI5SkGw52oFA=="
-		},
 		"fragment-cache": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
@@ -3815,6 +3115,7 @@
 			"version": "8.1.0",
 			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
 			"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.2.0",
 				"jsonfile": "^4.0.0",
@@ -3920,11 +3221,6 @@
 			"integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
 			"dev": true
 		},
-		"get-stdin": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-7.0.0.tgz",
-			"integrity": "sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ=="
-		},
 		"get-stream": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
@@ -3938,14 +3234,6 @@
 			"resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
 			"integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
 			"dev": true
-		},
-		"getpass": {
-			"version": "0.1.7",
-			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-			"requires": {
-				"assert-plus": "^1.0.0"
-			}
 		},
 		"glob": {
 			"version": "7.1.6",
@@ -4013,15 +3301,11 @@
 				"type-fest": "^0.8.1"
 			}
 		},
-		"google-libphonenumber": {
-			"version": "3.2.14",
-			"resolved": "https://registry.npmjs.org/google-libphonenumber/-/google-libphonenumber-3.2.14.tgz",
-			"integrity": "sha512-4r7mQRbk7EUYV1gyfP1SInYuQsjuDtRXCGLSotxeYDJaj/aF1xFO5PV/GSQeIxXWhIw050DujROICvWpZ1XYRw=="
-		},
 		"graceful-fs": {
 			"version": "4.2.4",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-			"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
+			"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+			"dev": true
 		},
 		"growl": {
 			"version": "1.10.5",
@@ -4042,20 +3326,6 @@
 				"wordwrap": "^1.0.0"
 			}
 		},
-		"har-schema": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
-		},
-		"har-validator": {
-			"version": "5.1.5",
-			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
-			"integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-			"requires": {
-				"ajv": "^6.12.3",
-				"har-schema": "^2.0.0"
-			}
-		},
 		"has": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -4067,7 +3337,8 @@
 		"has-flag": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"dev": true
 		},
 		"has-symbols": {
 			"version": "1.0.1",
@@ -4220,16 +3491,6 @@
 			"integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
 			"dev": true
 		},
-		"http-signature": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-			"requires": {
-				"assert-plus": "^1.0.0",
-				"jsprim": "^1.2.2",
-				"sshpk": "^1.7.0"
-			}
-		},
 		"https-browserify": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
@@ -4336,7 +3597,8 @@
 		"ini": {
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+			"dev": true
 		},
 		"inquirer": {
 			"version": "6.5.2",
@@ -4368,11 +3630,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
 			"integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA=="
-		},
-		"io-ts": {
-			"version": "2.2.11",
-			"resolved": "https://registry.npmjs.org/io-ts/-/io-ts-2.2.11.tgz",
-			"integrity": "sha512-lGxyPvZNhmo1U1Hy0ovjRtXljG6F59R3bZErK9XjiIQPlt4nuzbDNSwvalXvS7Z8iSZhx2S5GpNz5tVhpnDf6w=="
 		},
 		"is-accessor-descriptor": {
 			"version": "0.1.6",
@@ -4506,11 +3763,6 @@
 				"is-extglob": "^2.1.1"
 			}
 		},
-		"is-hex-prefixed": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz",
-			"integrity": "sha1-fY035q135dEnFIkTxXPggtd39VQ="
-		},
 		"is-nan": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.0.tgz",
@@ -4597,11 +3849,6 @@
 			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
 			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
 			"dev": true
-		},
-		"isstream": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
 		},
 		"istanbul-lib-coverage": {
 			"version": "3.0.0",
@@ -4729,11 +3976,6 @@
 				"istanbul-lib-report": "^3.0.0"
 			}
 		},
-		"jmespath": {
-			"version": "0.15.0",
-			"resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
-			"integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
-		},
 		"jquery": {
 			"version": "3.5.1",
 			"resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.1.tgz",
@@ -4761,11 +4003,6 @@
 				"esprima": "^4.0.0"
 			}
 		},
-		"jsbn": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
-		},
 		"jsesc": {
 			"version": "2.5.2",
 			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -4778,26 +4015,17 @@
 			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
 			"dev": true
 		},
-		"json-schema": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
-		},
 		"json-schema-traverse": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+			"dev": true
 		},
 		"json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
 			"integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
 			"dev": true
-		},
-		"json-stringify-safe": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
 		},
 		"json5": {
 			"version": "2.1.3",
@@ -4812,74 +4040,9 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
 			"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.6"
-			}
-		},
-		"jsonld": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/jsonld/-/jsonld-3.2.0.tgz",
-			"integrity": "sha512-re7FofG1iklGDlAthC4u5AMMt4l3qRNQbSI0nZTJu9vJG2R0QO6/yIhh8ZIh/M9Gg+EjXsULgQV/HEsltoVZBg==",
-			"requires": {
-				"canonicalize": "^1.0.1",
-				"lru-cache": "^5.1.1",
-				"object.fromentries": "^2.0.2",
-				"rdf-canonize": "^1.0.2",
-				"request": "^2.88.0",
-				"semver": "^6.3.0",
-				"xmldom": "0.1.19"
-			}
-		},
-		"jsonld-signatures": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/jsonld-signatures/-/jsonld-signatures-5.2.0.tgz",
-			"integrity": "sha512-/dGgMElXc3oBS+/OUwMc3DTK4riHKLE9Lk7NF1Upz2ZlBTNfnOw5uLRkFQOJFBDqDEm5hK6hIfkoC/rCWFh9tQ==",
-			"requires": {
-				"base64url": "^3.0.1",
-				"crypto-ld": "^3.7.0",
-				"jsonld": "^2.0.2",
-				"node-forge": "^0.10.0",
-				"security-context": "^4.0.0",
-				"serialize-error": "^5.0.0"
-			},
-			"dependencies": {
-				"jsonld": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/jsonld/-/jsonld-2.0.2.tgz",
-					"integrity": "sha512-/TQzRe75/3h2khu57IUojha5oat+M82bm8RYw0jLhlmmPrW/kTWAZ9nGzKPfZWnPYnVVJJMQVc/pU8HCmpv9xg==",
-					"requires": {
-						"canonicalize": "^1.0.1",
-						"lru-cache": "^5.1.1",
-						"rdf-canonize": "^1.0.2",
-						"request": "^2.88.0",
-						"semver": "^6.3.0",
-						"xmldom": "0.1.19"
-					}
-				}
-			}
-		},
-		"jsontokens": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-3.0.0.tgz",
-			"integrity": "sha512-P0QZC5AjOkn3t1ej6OuI7+XqoEctYj83UK4pw0WpHY4/z6a5PpZCJSpp5NZodq94GFkw2PfB9DPFoDM5qpyp/g==",
-			"requires": {
-				"@types/elliptic": "^6.4.9",
-				"asn1.js": "^5.0.1",
-				"base64url": "^3.0.1",
-				"ecdsa-sig-formatter": "^1.0.11",
-				"elliptic": "^6.4.1",
-				"sha.js": "^2.4.11"
-			}
-		},
-		"jsprim": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-			"requires": {
-				"assert-plus": "1.0.0",
-				"extsprintf": "1.3.0",
-				"json-schema": "0.2.3",
-				"verror": "1.10.0"
 			}
 		},
 		"just-extend": {
@@ -4887,24 +4050,6 @@
 			"resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.0.tgz",
 			"integrity": "sha512-ApcjaOdVTJ7y4r08xI5wIqpvwS48Q0PBG4DJROcEkH1f8MdAiNFyFxz3xoL0LWAVwjrwPYZdVHHxhRHcx/uGLA==",
 			"dev": true
-		},
-		"keccak": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.1.tgz",
-			"integrity": "sha512-epq90L9jlFWCW7+pQa6JOnKn2Xgl2mtI664seYR6MHskvI9agt7AnDqmAlp9TqU4/caMYbA08Hi5DMZAl5zdkA==",
-			"requires": {
-				"node-addon-api": "^2.0.0",
-				"node-gyp-build": "^4.2.0"
-			}
-		},
-		"keccak256": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/keccak256/-/keccak256-1.0.1.tgz",
-			"integrity": "sha512-wJM3lUBboGc5nOH3iIkFFWnnI8km0RHspLqfedDPCHvdHFVOhArGkx27KdaqOd2/gqqMUeWBThEs8iuC4mZZHQ==",
-			"requires": {
-				"bn.js": "^4.11.8",
-				"keccak": "^3.0.1"
-			}
 		},
 		"kind-of": {
 			"version": "6.0.3",
@@ -5019,16 +4164,6 @@
 			"integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
 			"dev": true
 		},
-		"lodash.keyby": {
-			"version": "4.6.0",
-			"resolved": "https://registry.npmjs.org/lodash.keyby/-/lodash.keyby-4.6.0.tgz",
-			"integrity": "sha1-f2oavak/0k4icopNNh7YvLpaQ1Q="
-		},
-		"lodash.uniq": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
-			"integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
-		},
 		"log-symbols": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
@@ -5051,6 +4186,7 @@
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
 			"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+			"dev": true,
 			"requires": {
 				"yallist": "^3.0.2"
 			}
@@ -5292,19 +4428,6 @@
 			"requires": {
 				"bn.js": "^4.0.0",
 				"brorand": "^1.0.1"
-			}
-		},
-		"mime-db": {
-			"version": "1.44.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
-			"integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg=="
-		},
-		"mime-types": {
-			"version": "2.1.27",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
-			"integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
-			"requires": {
-				"mime-db": "1.44.0"
 			}
 		},
 		"mimic-fn": {
@@ -5618,25 +4741,6 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 		},
-		"multibase": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/multibase/-/multibase-3.0.1.tgz",
-			"integrity": "sha512-MRU5WpnSg81/vYO977MweoeUAxBdXl7+F5Af2Es+X6Vcgfk/g/EjIqXTgm3kb+xO3m1Kzr+aIV14oRX7nv5Z9w==",
-			"requires": {
-				"@multiformats/base-x": "^4.0.1",
-				"web-encoding": "^1.0.2"
-			}
-		},
-		"multihashes": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/multihashes/-/multihashes-3.0.1.tgz",
-			"integrity": "sha512-fFY67WOtb0359IjDZxaCU3gJILlkwkFbxbwrK9Bej5+NqNaYztzLOj8/NgMNMg/InxmhK+Uu8S/U4EcqsHzB7Q==",
-			"requires": {
-				"multibase": "^3.0.0",
-				"uint8arrays": "^1.0.0",
-				"varint": "^5.0.0"
-			}
-		},
 		"mute-stream": {
 			"version": "0.0.7",
 			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
@@ -5696,11 +4800,6 @@
 				"path-to-regexp": "^1.7.0"
 			}
 		},
-		"node-addon-api": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
-			"integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
-		},
 		"node-environment-flags": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.6.tgz",
@@ -5723,16 +4822,6 @@
 			"version": "2.6.0",
 			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
 			"integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
-		},
-		"node-forge": {
-			"version": "0.10.0",
-			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
-			"integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
-		},
-		"node-gyp-build": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
-			"integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg=="
 		},
 		"node-libs-browser": {
 			"version": "2.2.1",
@@ -6170,11 +5259,6 @@
 				}
 			}
 		},
-		"oauth-sign": {
-			"version": "0.9.0",
-			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
-		},
 		"object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -6255,17 +5339,6 @@
 				"function-bind": "^1.1.1",
 				"has-symbols": "^1.0.0",
 				"object-keys": "^1.0.11"
-			}
-		},
-		"object.fromentries": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.2.tgz",
-			"integrity": "sha512-r3ZiBH7MQppDJVLx6fhD618GKNG40CZYH9wgwdhKxBDDbQgjeWGGd4AtkZad84d291YxvWe7bJGuE65Anh0dxQ==",
-			"requires": {
-				"define-properties": "^1.1.3",
-				"es-abstract": "^1.17.0-next.1",
-				"function-bind": "^1.1.1",
-				"has": "^1.0.3"
 			}
 		},
 		"object.getownpropertydescriptors": {
@@ -6422,7 +5495,8 @@
 		"pako": {
 			"version": "1.0.11",
 			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-			"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+			"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+			"dev": true
 		},
 		"parallel-transform": {
 			"version": "1.2.0",
@@ -6582,11 +5656,6 @@
 				"sha.js": "^2.4.8"
 			}
 		},
-		"performance-now": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
-		},
 		"picomatch": {
 			"version": "2.2.2",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
@@ -6735,11 +5804,6 @@
 			"integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
 			"dev": true
 		},
-		"psl": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-			"integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
-		},
 		"public-encrypt": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
@@ -6788,17 +5852,14 @@
 		"punycode": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
-		},
-		"qs": {
-			"version": "6.5.2",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+			"dev": true
 		},
 		"querystring": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-			"integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+			"integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+			"dev": true
 		},
 		"querystring-es3": {
 			"version": "0.2.1",
@@ -6831,15 +5892,6 @@
 			"requires": {
 				"randombytes": "^2.0.5",
 				"safe-buffer": "^5.1.0"
-			}
-		},
-		"rdf-canonize": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/rdf-canonize/-/rdf-canonize-1.2.0.tgz",
-			"integrity": "sha512-MQdcRDz4+82nUrEb3hNQangBDpmep15uMmnWclGi/1KS0bNVc8oHpoNI0PFLHZsvwgwRzH31bO1JAScqUAstvw==",
-			"requires": {
-				"node-forge": "^0.10.0",
-				"semver": "^6.3.0"
 			}
 		},
 		"react": {
@@ -6998,11 +6050,6 @@
 				"resolve": "^1.1.6"
 			}
 		},
-		"reflect-metadata": {
-			"version": "0.1.13",
-			"resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
-			"integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
-		},
 		"regex-not": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
@@ -7046,33 +6093,6 @@
 			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
 			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
 			"dev": true
-		},
-		"request": {
-			"version": "2.88.2",
-			"resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-			"integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-			"requires": {
-				"aws-sign2": "~0.7.0",
-				"aws4": "^1.8.0",
-				"caseless": "~0.12.0",
-				"combined-stream": "~1.0.6",
-				"extend": "~3.0.2",
-				"forever-agent": "~0.6.1",
-				"form-data": "~2.3.2",
-				"har-validator": "~5.1.3",
-				"http-signature": "~1.2.0",
-				"is-typedarray": "~1.0.0",
-				"isstream": "~0.1.2",
-				"json-stringify-safe": "~5.0.1",
-				"mime-types": "~2.1.19",
-				"oauth-sign": "~0.9.0",
-				"performance-now": "^2.1.0",
-				"qs": "~6.5.2",
-				"safe-buffer": "^5.1.2",
-				"tough-cookie": "~2.5.0",
-				"tunnel-agent": "^0.6.0",
-				"uuid": "^3.3.2"
-			}
 		},
 		"require-directory": {
 			"version": "2.1.1",
@@ -7160,11 +6180,6 @@
 			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
 			"dev": true
 		},
-		"retry": {
-			"version": "0.12.0",
-			"resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-			"integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs="
-		},
 		"rimraf": {
 			"version": "2.7.1",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
@@ -7181,14 +6196,6 @@
 			"requires": {
 				"hash-base": "^3.0.0",
 				"inherits": "^2.0.1"
-			}
-		},
-		"rlp": {
-			"version": "2.2.6",
-			"resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.6.tgz",
-			"integrity": "sha512-HAfAmL6SDYNWPUOJNrM500x4Thn4PZsEy5pijPh40U9WfNk0z15hUYzO9xVIMAdIHdFtD8CBDHd75Td1g36Mjg==",
-			"requires": {
-				"bn.js": "^4.11.1"
 			}
 		},
 		"run-async": {
@@ -7232,11 +6239,6 @@
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
 		},
-		"sax": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
-			"integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
-		},
 		"schema-utils": {
 			"version": "2.7.0",
 			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.0.tgz",
@@ -7247,11 +6249,6 @@
 				"ajv": "^6.12.2",
 				"ajv-keywords": "^3.4.1"
 			}
-		},
-		"scrypt-js": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
-			"integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA=="
 		},
 		"secp256k1": {
 			"version": "3.8.0",
@@ -7268,23 +6265,11 @@
 				"safe-buffer": "^5.1.2"
 			}
 		},
-		"security-context": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/security-context/-/security-context-4.0.0.tgz",
-			"integrity": "sha512-yiDCS7tpKQl6p4NG57BdKLTSNLFfj5HosBIzXBl4jZf/qorJzSzbEUIdLhN+vVYgyLlvjixY8DPPTgqI8zvNCA=="
-		},
 		"semver": {
 			"version": "6.3.0",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-		},
-		"serialize-error": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-5.0.0.tgz",
-			"integrity": "sha512-/VtpuyzYf82mHYTtI4QKtwHa79vAdU5OQpNPAmE/0UDdlGT0ZxHwC+J6gXkw29wwoVI8fMPsfcVHOwXtUQYYQA==",
-			"requires": {
-				"type-fest": "^0.8.0"
-			}
+			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+			"dev": true
 		},
 		"serialize-javascript": {
 			"version": "2.1.2",
@@ -7323,7 +6308,8 @@
 		"setimmediate": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+			"dev": true
 		},
 		"sha.js": {
 			"version": "2.4.11",
@@ -7558,16 +6544,6 @@
 				}
 			}
 		},
-		"sodium-native": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-3.2.0.tgz",
-			"integrity": "sha512-8aq/vQSegLwsRch8Sb/Bpf9aAqlNe5dp0+NVhb9UjHv42zDZ0D5zX3wBRUbXK9Ejum9uZE6DUgT4vVLlUFRBWg==",
-			"optional": true,
-			"requires": {
-				"ini": "^1.3.5",
-				"node-gyp-build": "^4.2.0"
-			}
-		},
 		"source-list-map": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
@@ -7717,22 +6693,6 @@
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
 			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
 			"dev": true
-		},
-		"sshpk": {
-			"version": "1.16.1",
-			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
-			"integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
-			"requires": {
-				"asn1": "~0.2.3",
-				"assert-plus": "^1.0.0",
-				"bcrypt-pbkdf": "^1.0.0",
-				"dashdash": "^1.12.0",
-				"ecc-jsbn": "~0.1.1",
-				"getpass": "^0.1.1",
-				"jsbn": "~0.1.0",
-				"safer-buffer": "^2.0.2",
-				"tweetnacl": "~0.14.0"
-			}
 		},
 		"ssri": {
 			"version": "7.1.0",
@@ -7911,14 +6871,6 @@
 			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
 			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
 		},
-		"strip-hex-prefix": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/strip-hex-prefix/-/strip-hex-prefix-1.0.0.tgz",
-			"integrity": "sha1-DF8VX+8RUTczd96du1iNoFUA428=",
-			"requires": {
-				"is-hex-prefixed": "1.0.0"
-			}
-		},
 		"strip-json-comments": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -7929,6 +6881,7 @@
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
 			"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+			"dev": true,
 			"requires": {
 				"has-flag": "^4.0.0"
 			}
@@ -8172,11 +7125,6 @@
 				"nan": "^2.13.2"
 			}
 		},
-		"tiny-warning": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
-			"integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
-		},
 		"tmp": {
 			"version": "0.0.33",
 			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -8244,15 +7192,6 @@
 				"is-number": "^7.0.0"
 			}
 		},
-		"tough-cookie": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-			"integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-			"requires": {
-				"psl": "^1.1.28",
-				"punycode": "^2.1.1"
-			}
-		},
 		"treeify": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/treeify/-/treeify-1.1.0.tgz",
@@ -8280,11 +7219,6 @@
 				}
 			}
 		},
-		"ts-toolbelt": {
-			"version": "6.15.5",
-			"resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-6.15.5.tgz",
-			"integrity": "sha512-FZIXf1ksVyLcfr7M317jbB67XFJhOO1YqdTcuGaq9q5jLUoTikukZ+98TPjKiP2jC5CgmYdWWYs0s2nLSU0/1A=="
-		},
 		"tslib": {
 			"version": "1.13.0",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
@@ -8305,19 +7239,6 @@
 			"integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
 			"dev": true
 		},
-		"tunnel-agent": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-			"requires": {
-				"safe-buffer": "^5.0.1"
-			}
-		},
-		"tweetnacl": {
-			"version": "0.14.5",
-			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
-		},
 		"type-check": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -8336,7 +7257,8 @@
 		"type-fest": {
 			"version": "0.8.1",
 			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-			"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="
+			"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+			"dev": true
 		},
 		"typedarray": {
 			"version": "0.0.6",
@@ -8409,15 +7331,6 @@
 			"dev": true,
 			"optional": true
 		},
-		"uint8arrays": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-1.1.0.tgz",
-			"integrity": "sha512-cLdlZ6jnFczsKf5IH1gPHTtcHtPGho5r4CvctohmQjw8K7Q3gFdfIGHxSTdTaCKrL4w09SsPRJTqRS0drYeszA==",
-			"requires": {
-				"multibase": "^3.0.0",
-				"web-encoding": "^1.0.2"
-			}
-		},
 		"underscore": {
 			"version": "1.10.2",
 			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.10.2.tgz",
@@ -8457,7 +7370,8 @@
 		"universalify": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+			"dev": true
 		},
 		"unset-value": {
 			"version": "1.0.0",
@@ -8510,6 +7424,7 @@
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
 			"integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+			"dev": true,
 			"requires": {
 				"punycode": "^2.1.0"
 			}
@@ -8519,22 +7434,6 @@
 			"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
 			"integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
 			"dev": true
-		},
-		"url": {
-			"version": "0.10.3",
-			"resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
-			"integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
-			"requires": {
-				"punycode": "1.3.2",
-				"querystring": "0.2.0"
-			},
-			"dependencies": {
-				"punycode": {
-					"version": "1.3.2",
-					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-					"integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
-				}
-			}
 		},
 		"use": {
 			"version": "3.1.1",
@@ -8585,69 +7484,6 @@
 			"requires": {
 				"spdx-correct": "^3.0.0",
 				"spdx-expression-parse": "^3.0.0"
-			}
-		},
-		"validator": {
-			"version": "13.0.0",
-			"resolved": "https://registry.npmjs.org/validator/-/validator-13.0.0.tgz",
-			"integrity": "sha512-anYx5fURbgF04lQV18nEQWZ/3wHGnxiKdG4aL8J+jEDsm98n/sU/bey+tYk6tnGJzm7ioh5FoqrAiQ6m03IgaA=="
-		},
-		"varint": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
-			"integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow=="
-		},
-		"vc-js": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/vc-js/-/vc-js-0.5.0.tgz",
-			"integrity": "sha512-ge66+guw0ezYdA7u71PjRuoKkHtt+u4dBmWT7HgIOeTHniHRtlobSeq2c+2YncYFyvDyVMLOCyiYhCiz3Augog==",
-			"requires": {
-				"commander": "^2.20.3",
-				"credentials-context": "^1.0.0",
-				"debug": "^4.1.1",
-				"fs-extra": "^8.1.0",
-				"get-stdin": "^7.0.0",
-				"jsonld": "^2.0.2",
-				"jsonld-signatures": "^5.0.0",
-				"supports-color": "^7.1.0"
-			},
-			"dependencies": {
-				"jsonld": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/jsonld/-/jsonld-2.0.2.tgz",
-					"integrity": "sha512-/TQzRe75/3h2khu57IUojha5oat+M82bm8RYw0jLhlmmPrW/kTWAZ9nGzKPfZWnPYnVVJJMQVc/pU8HCmpv9xg==",
-					"requires": {
-						"canonicalize": "^1.0.1",
-						"lru-cache": "^5.1.1",
-						"rdf-canonize": "^1.0.2",
-						"request": "^2.88.0",
-						"semver": "^6.3.0",
-						"xmldom": "0.1.19"
-					}
-				}
-			}
-		},
-		"vc-revocation-list": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/vc-revocation-list/-/vc-revocation-list-2.0.0.tgz",
-			"integrity": "sha512-mWLHOV3DI5PDxC+Qv5psCcduNhRsRqTgAMMkA4zDKYnJkjJBC21/BDqAv82X60u/U5cc5bc2qlJXl4d4ccUgqg==",
-			"requires": {
-				"@digitalbazaar/bitstring": "^1.1.0",
-				"base64url-universal": "^1.1.0",
-				"esm": "^3.2.25",
-				"jsonld-signatures": "^5.0.1",
-				"pako": "^1.0.11",
-				"vc-js": "^0.5.0"
-			}
-		},
-		"verror": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-			"requires": {
-				"assert-plus": "^1.0.0",
-				"core-util-is": "1.0.2",
-				"extsprintf": "^1.2.0"
 			}
 		},
 		"vm-browserify": {
@@ -8927,11 +7763,6 @@
 					}
 				}
 			}
-		},
-		"web-encoding": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.0.4.tgz",
-			"integrity": "sha512-DcXs2lbVPzuJmn2kuDEwul2oZg7p4YMa5J2f0YzsOBHaAnBYGPNUB/rJ74DTjTKpw7F0+lSsVM8sFHE2UyBixg=="
 		},
 		"webpack": {
 			"version": "4.44.1",
@@ -9253,15 +8084,6 @@
 				"uuid": "^3.3.2"
 			}
 		},
-		"xml2js": {
-			"version": "0.4.19",
-			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
-			"integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
-			"requires": {
-				"sax": ">=0.6.0",
-				"xmlbuilder": "~9.0.1"
-			}
-		},
 		"xmlbuilder": {
 			"version": "9.0.7",
 			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
@@ -9286,7 +8108,8 @@
 		"yallist": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-			"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+			"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+			"dev": true
 		},
 		"yargs": {
 			"version": "12.0.5",

--- a/sdk/react-native/package-lock.json
+++ b/sdk/react-native/package-lock.json
@@ -4,6 +4,15 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@affinidi/affinity-metrics-lib": {
+			"version": "0.0.18",
+			"resolved": "https://registry.npmjs.org/@affinidi/affinity-metrics-lib/-/affinity-metrics-lib-0.0.18.tgz",
+			"integrity": "sha512-yeorbuxXdUxuT6RenyYbvO8Ifp3J9beg4oIrE77WjxNgrtSFzhiiM98rJ6j6Peegs31YGSFWrpjDTjD56GZbPA==",
+			"requires": {
+				"keccak256": "^1.0.0",
+				"node-fetch": "^2.6.0"
+			}
+		},
 		"@affinidi/eslint-config": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@affinidi/eslint-config/-/eslint-config-1.0.1.tgz",
@@ -4051,6 +4060,24 @@
 			"integrity": "sha512-ApcjaOdVTJ7y4r08xI5wIqpvwS48Q0PBG4DJROcEkH1f8MdAiNFyFxz3xoL0LWAVwjrwPYZdVHHxhRHcx/uGLA==",
 			"dev": true
 		},
+		"keccak": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.1.tgz",
+			"integrity": "sha512-epq90L9jlFWCW7+pQa6JOnKn2Xgl2mtI664seYR6MHskvI9agt7AnDqmAlp9TqU4/caMYbA08Hi5DMZAl5zdkA==",
+			"requires": {
+				"node-addon-api": "^2.0.0",
+				"node-gyp-build": "^4.2.0"
+			}
+		},
+		"keccak256": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/keccak256/-/keccak256-1.0.1.tgz",
+			"integrity": "sha512-wJM3lUBboGc5nOH3iIkFFWnnI8km0RHspLqfedDPCHvdHFVOhArGkx27KdaqOd2/gqqMUeWBThEs8iuC4mZZHQ==",
+			"requires": {
+				"bn.js": "^4.11.8",
+				"keccak": "^3.0.1"
+			}
+		},
 		"kind-of": {
 			"version": "6.0.3",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -4800,6 +4827,11 @@
 				"path-to-regexp": "^1.7.0"
 			}
 		},
+		"node-addon-api": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
+			"integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
+		},
 		"node-environment-flags": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.6.tgz",
@@ -4822,6 +4854,11 @@
 			"version": "2.6.0",
 			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
 			"integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+		},
+		"node-gyp-build": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
+			"integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg=="
 		},
 		"node-libs-browser": {
 			"version": "2.2.1",

--- a/sdk/react-native/package.json
+++ b/sdk/react-native/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "@affinidi/common": "1.1.2",
     "@affinidi/wallet-core-sdk": "2.0.3",
+    "@affinidi/affinity-metrics-lib": "0.0.18",
     "@react-native-community/netinfo": "^5.9.3",
     "@sentry/react-native": "^1.5.0",
     "@types/text-encoding": "0.0.35",

--- a/sdk/react-native/package.json
+++ b/sdk/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@affinidi/wallet-react-native-sdk",
-  "version": "2.0.1",
+  "version": "2.0.3",
   "description": "SDK for affinity DID solution for React Native",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -34,7 +34,7 @@
   "license": "ISC",
   "dependencies": {
     "@affinidi/common": "1.1.2",
-    "@affinidi/wallet-core-sdk": "2.0.1",
+    "@affinidi/wallet-core-sdk": "2.0.3",
     "@react-native-community/netinfo": "^5.9.3",
     "@sentry/react-native": "^1.5.0",
     "@types/text-encoding": "0.0.35",

--- a/sdk/react-native/src/AffinityWallet.ts
+++ b/sdk/react-native/src/AffinityWallet.ts
@@ -1,4 +1,5 @@
-import { CommonNetworkMember as CoreNetwork, __dangerous, EventComponent } from '@affinidi/wallet-core-sdk'
+import { CommonNetworkMember as CoreNetwork, __dangerous } from '@affinidi/wallet-core-sdk'
+import { EventComponent } from '@affinidi/affinity-metrics-lib'
 
 import KeysService from './services/KeysService'
 import WalletStorageService from './services/WalletStorageService'

--- a/sdk/react-native/src/AffinityWallet.ts
+++ b/sdk/react-native/src/AffinityWallet.ts
@@ -1,4 +1,4 @@
-import { CommonNetworkMember as CoreNetwork, __dangerous } from '@affinidi/wallet-core-sdk'
+import { CommonNetworkMember as CoreNetwork, __dangerous, EventComponent } from '@affinidi/wallet-core-sdk'
 
 import KeysService from './services/KeysService'
 import WalletStorageService from './services/WalletStorageService'
@@ -18,6 +18,7 @@ export class AffinityWallet extends CoreNetwork {
 
     this.keysService = new KeysService(encryptedSeed, password)
     this.walletStorageService = new WalletStorageService(encryptedSeed, password, sdkOptions)
+    this._component = EventComponent.AffinidiReactNativeSDK
   }
 
   /**

--- a/sdk/react-native/src/AffinityWallet.ts
+++ b/sdk/react-native/src/AffinityWallet.ts
@@ -8,18 +8,24 @@ type SdkOptions = __dangerous.SdkOptions & {
   issueSignupCredential?: boolean
 }
 
+const COMPONENT = EventComponent.AffinidiReactNativeSDK
+
 export class AffinityWallet extends CoreNetwork {
   keysService: KeysService
   walletStorageService: WalletStorageService
 
-  constructor(password: string, encryptedSeed: string, options: __dangerous.SdkOptions = {}) {
-    super(password, encryptedSeed, options)
+  constructor(
+    password: string,
+    encryptedSeed: string,
+    options: __dangerous.SdkOptions = {},
+    component: EventComponent = COMPONENT,
+  ) {
+    super(password, encryptedSeed, options, component)
 
     const sdkOptions = CoreNetwork.setEnvironmentVarialbles(options)
 
     this.keysService = new KeysService(encryptedSeed, password)
     this.walletStorageService = new WalletStorageService(encryptedSeed, password, sdkOptions)
-    this._component = EventComponent.AffinidiReactNativeSDK
   }
 
   /**


### PR DESCRIPTION
https://replika.atlassian.net/browse/NEP-957

Currently in Core SDK all wallet implementations (browser/expo/rn/cloud) are using `AffinityBrowserExpoSDK` as component name. We should instead use different namings to distinguish these components when sending an event.

Also take the chance to update keyword `affinity` to `affinidi` in component enum.

Corresponding changes in metrics-lib: https://github.com/affinityproject/affinity-metrics-lib/pull/16