### PR TITLE
fix: Pass accessApiKey to ApiService. Bump SDK 3.0.1

### DIFF
--- a/sdk/browser/package-lock.json
+++ b/sdk/browser/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@affinidi/wallet-browser-sdk",
-	"version": "3.0.0",
+	"version": "3.0.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/sdk/browser/package.json
+++ b/sdk/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@affinidi/wallet-browser-sdk",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "SDK monorepo for affinity DID solution for browser",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -40,7 +40,7 @@
   "license": "ISC",
   "dependencies": {
     "@affinidi/common": "1.1.2",
-    "@affinidi/wallet-core-sdk": "3.0.0",
+    "@affinidi/wallet-core-sdk": "3.0.1",
     "@affinidi/affinity-metrics-lib": "0.0.18",
     "@sentry/browser": "^5.18.0",
     "bip32": "^2.0.5",

--- a/sdk/core/package-lock.json
+++ b/sdk/core/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@affinidi/wallet-core-sdk",
-	"version": "3.0.0",
+	"version": "3.0.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/sdk/core/package.json
+++ b/sdk/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@affinidi/wallet-core-sdk",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "SDK core monorepo for affinity DID solution",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/sdk/core/src/CommonNetworkMember.ts
+++ b/sdk/core/src/CommonNetworkMember.ts
@@ -145,7 +145,7 @@ export class CommonNetworkMember {
 
     this._component = component
     this._metricsService = new MetricsService({ metricsUrl, apiKey: this._accessApiKey }, this._component)
-    this._api = new API(registryUrl, issuerUrl, verifierUrl, { apiKey: this._accessApiKey })
+    this._api = new API(registryUrl, issuerUrl, verifierUrl, { accessApiKey: this._accessApiKey })
     this._walletStorageService = new WalletStorageService(encryptedSeed, password, this._sdkOptions)
     this._revocationService = new RevocationService(this._sdkOptions)
     this._keysService = new KeysService(encryptedSeed, password)
@@ -410,7 +410,7 @@ export class CommonNetworkMember {
 
     const accessApiKey = CommonNetworkMember._setAccessApiKey(options)
 
-    const api = new API(registryUrl, null, null, { apiKey: accessApiKey })
+    const api = new API(registryUrl, null, null, { accessApiKey })
 
     const did = didDocument.id
 
@@ -630,9 +630,7 @@ export class CommonNetworkMember {
 
     const { accessToken } = options.cognitoUserTokens
 
-    const apiKey = CommonNetworkMember._setAccessApiKey(options)
-
-    const encryptedSeed = await WalletStorageService.pullEncryptedSeed(accessToken, keyStorageUrl, { apiKey })
+    const encryptedSeed = await WalletStorageService.pullEncryptedSeed(accessToken, keyStorageUrl, options)
     const encryptionKey = await WalletStorageService.pullEncryptionKey(accessToken)
 
     return new this(encryptionKey, encryptedSeed, options)
@@ -669,6 +667,7 @@ export class CommonNetworkMember {
 
     options.keyStorageUrl = keyStorageUrl
     options.registryUrl = registryUrl
+
     return WalletStorageService.getSignedCredentials(idToken, credentialOfferResponseToken, options)
   }
 
@@ -864,12 +863,10 @@ export class CommonNetworkMember {
 
     password = normalizeShortPassword(password, username)
 
-    const { keyStorageUrl, userPoolId, clientId } = CommonNetworkMember.setEnvironmentVarialbles(options)
-
-    const apiKey = CommonNetworkMember._setAccessApiKey(options)
+    const { userPoolId, clientId } = CommonNetworkMember.setEnvironmentVarialbles(options)
 
     const cognitoService = new CognitoService({ userPoolId, clientId })
-    await cognitoService.signUp(username, password, messageParameters, { keyStorageUrl, userPoolId, clientId, apiKey })
+    await cognitoService.signUp(username, password, messageParameters, options)
 
     const token = `${username}::${password}`
 
@@ -949,14 +946,12 @@ export class CommonNetworkMember {
 
     const { isUsername } = validateUsername(username)
 
-    const { userPoolId, clientId, keyStorageUrl } = CommonNetworkMember.setEnvironmentVarialbles(options)
-
-    const apiKey = CommonNetworkMember._setAccessApiKey(options)
+    const { userPoolId, clientId } = CommonNetworkMember.setEnvironmentVarialbles(options)
 
     const cognitoService = new CognitoService({ userPoolId, clientId })
 
     if (isUsername) {
-      await WalletStorageService.adminConfirmUser(username, { keyStorageUrl, apiKey })
+      await WalletStorageService.adminConfirmUser(username, options)
     } else {
       await cognitoService.confirmSignUp(username, confirmationCode)
     }

--- a/sdk/core/src/services/WalletStorageService.ts
+++ b/sdk/core/src/services/WalletStorageService.ts
@@ -6,6 +6,8 @@ import SdkError from '../shared/SdkError'
 import { profile } from '@affinidi/common'
 import { JwtService, KeysService } from '@affinidi/common'
 
+import { Env } from '../dto/shared.dto'
+
 import { FreeFormObject } from '../shared/interfaces'
 
 const keccak256 = require('keccak256')
@@ -389,7 +391,10 @@ export default class WalletStorageService {
   static async getCredentialOffer(idToken: string, keyStorageUrl?: string, options: any = {}): Promise<string> {
     keyStorageUrl = keyStorageUrl || STAGING_KEY_STORAGE_URL
 
-    const url = `${keyStorageUrl}/api/v1/issuer/getCredentialOffer`
+    const env: Env = options.env
+
+    const url = `${keyStorageUrl}/api/v1/issuer/getCredentialOffer?env=${env}`
+
     const headers = {
       authorization: idToken,
     }

--- a/sdk/expo/package-lock.json
+++ b/sdk/expo/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@affinidi/wallet-expo-sdk",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/sdk/expo/package.json
+++ b/sdk/expo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@affinidi/wallet-expo-sdk",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "SDK monorepo for affinity DID solution for Expo",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -41,7 +41,7 @@
   "license": "ISC",
   "dependencies": {
     "@affinidi/common": "1.1.2",
-    "@affinidi/wallet-core-sdk": "3.0.0",
+    "@affinidi/wallet-core-sdk": "3.0.1",
     "@affinidi/affinity-metrics-lib": "0.0.18",
     "@react-native-community/netinfo": "^5.5.1",
     "@types/text-encoding": "0.0.35",

--- a/sdk/react-native/package-lock.json
+++ b/sdk/react-native/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@affinidi/wallet-react-native-sdk",
-	"version": "3.0.0",
+	"version": "3.0.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/sdk/react-native/package.json
+++ b/sdk/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@affinidi/wallet-react-native-sdk",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "SDK for affinity DID solution for React Native",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -34,7 +34,7 @@
   "license": "ISC",
   "dependencies": {
     "@affinidi/common": "1.1.2",
-    "@affinidi/wallet-core-sdk": "3.0.0",
+    "@affinidi/wallet-core-sdk": "3.0.1",
     "@affinidi/affinity-metrics-lib": "0.0.18",
     "@react-native-community/netinfo": "^5.9.3",
     "@sentry/react-native": "^1.5.0",


### PR DESCRIPTION
Send ENV to getCredentialOffer (wallet-backend)