### PR TITLE
change revocation api default urls

### DIFF
--- a/sdk/core/package.json
+++ b/sdk/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@affinidi/wallet-core-sdk",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "description": "SDK core monorepo for affinity DID solution",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/sdk/core/src/_defaultConfig.ts
+++ b/sdk/core/src/_defaultConfig.ts
@@ -10,7 +10,7 @@ export const DEV_VAULT_URL = 'https://bloom-vault.dev.affinity-project.org'
 export const DEV_PHONE_ISSUER_BASE_PATH = 'https://issuer-phone-twillio.dev.affinity-project.org'
 export const DEV_EMAIL_ISSUER_BASE_PATH = 'https://issuer-email-ses.dev.affinity-project.org'
 export const DEV_METRICS_URL = 'https://affinity-metrics.dev.affinity-project.org'
-export const DEV_REVOCATION_URL = 'https://affinity-issuer.dev.affinity-project.org'
+export const DEV_REVOCATION_URL = 'https://revocation-api.dev.affinity-project.org'
 
 export const STAGING_COGNITO_CLIENT_ID = '3kkiu7rski2ob6r1lk0nk7k4ft'
 export const STAGING_COGNITO_USER_POOL_ID = 'ap-southeast-1_z8q6rRlJV'
@@ -22,7 +22,7 @@ export const STAGING_VAULT_URL = 'https://bloom-vault.staging.affinity-project.o
 export const STAGING_PHONE_ISSUER_BASE_PATH = 'https://issuer-phone-twillio.staging.affinity-project.org'
 export const STAGING_EMAIL_ISSUER_BASE_PATH = 'https://issuer-email-ses.staging.affinity-project.org'
 export const STAGING_METRICS_URL = 'https://affinity-metrics.staging.affinity-project.org'
-export const STAGING_REVOCATION_URL = 'https://affinity-issuer.staging.affinity-project.org'
+export const STAGING_REVOCATION_URL = 'https://revocation-api.staging.affinity-project.org'
 
 export const PROD_COGNITO_CLIENT_ID = '4ds756i9ji54tagaj8as9041qc'
 export const PROD_COGNITO_USER_POOL_ID = 'ap-southeast-1_Og0weulSg'
@@ -34,7 +34,7 @@ export const PROD_VAULT_URL = 'https://bloom-vault.prod.affinity-project.org'
 export const PROD_PHONE_ISSUER_BASE_PATH = 'https://issuer-phone-twillio.prod.affinity-project.org'
 export const PROD_EMAIL_ISSUER_BASE_PATH = 'https://issuer-email-ses.prod.affinity-project.org'
 export const PROD_METRICS_URL = 'https://affinity-metrics.prod.affinity-project.org'
-export const PROD_REVOCATION_URL = 'https://affinity-issuer.prod.affinity-project.org'
+export const PROD_REVOCATION_URL = 'https://revocation-api.prod.affinity-project.org'
 
 export const DEFAULT_JWT_EXPIRY_MS = 10 * 60 * 1000
 export const MINIMUM_RECOMMENDED_PASSWORD_LENGTH = 8


### PR DESCRIPTION
## Description
Recently deployed `revocation-api` should be used as the default revocation API URL.

### Todo
- [ ] deploy revocation api to all envs