### PR TITLE
add pagination to WalletStorageService when accessing vault

### DIFF
--- a/sdk/browser/CHANGELOG.md
+++ b/sdk/browser/CHANGELOG.md
@@ -1,6 +1,7 @@
 # release 4.2.3 (2020-04-01)
  * add optional pagination to `AffinityWallet.getCredentials`
  * add new method `AffinityWallet.getCredentialByIndex` that returns credentials given at the index
+ * fix `AffinityWallet.signUp` returning CommonNetworkMember instead of Browser AffinityWallet
 # release 4.2.2 
  * use new `vc-data` 
 # release 4.2.0 (2020-02-16)

--- a/sdk/browser/CHANGELOG.md
+++ b/sdk/browser/CHANGELOG.md
@@ -1,4 +1,4 @@
-# release 4.2.3
+# release 4.2.3 (2020-04-01)
  * add optional pagination to `AffinityWallet.getCredentials`
  * add new method `AffinityWallet.getCredentialByIndex` that returns credentials given at the index
 # release 4.2.2 

--- a/sdk/browser/CHANGELOG.md
+++ b/sdk/browser/CHANGELOG.md
@@ -1,3 +1,6 @@
+# release 4.2.3
+ * add optional pagination to `AffinityWallet.getCredentials`
+ * add new method `AffinityWallet.getCredentialByIndex` that returns credentials given at the index
 # release 4.2.2 
  * use new `vc-data` 
 # release 4.2.0 (2020-02-16)

--- a/sdk/browser/README.md
+++ b/sdk/browser/README.md
@@ -91,12 +91,31 @@ Region should be a 3 character string correlating to an Alpha-3 country code.
 
 ### Pull credential from VC vault
 
+#### All Credentials Matching the shareRequestToken
 ```ts
 const credentials = await affinityWallet.getCredentials(shareRequestToken)
 ```
 
 `shareRequestToken` - optional parameter (if passed - returns VC,
-which match the request, if not - then returns all VCs).
+which match the request, if not provided - then returns credentials with pagination of `{ skip: 0, limit: 100 }`).
+
+#### Some Credentials With Pagination
+```ts
+const credentials = await affinityWallet.getCredentials(null, paginationOptions)
+```
+
+`paginationOptions` is an optional parameter in the format of: `{ skip: number, limit: number }`. If given, the wallet will only pull credentials in given subset. E.g. `{ skip: 2, limit: 3 }` means fetching the credentials at indexes `2,3,4`
+
+`skip` can be omitted and has a default value of 0.
+
+`limit` can be omitted and has a default value of 100.
+
+#### A Single Credential
+```ts
+const credential = await affinityWallet.getCredentialByIndex(credentialIndex)
+```
+
+`credentialIndex` is a required parameter which is type of number.
 
 ### Get credential issued during signup process
 

--- a/sdk/browser/package-lock.json
+++ b/sdk/browser/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@affinidi/wallet-browser-sdk",
-	"version": "4.2.2",
+	"version": "4.2.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/sdk/browser/package.json
+++ b/sdk/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@affinidi/wallet-browser-sdk",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "description": "SDK monorepo for affinity DID solution for browser",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -40,7 +40,7 @@
   "license": "ISC",
   "dependencies": {
     "@affinidi/common": "1.6.0",
-    "@affinidi/wallet-core-sdk": "4.2.2",
+    "@affinidi/wallet-core-sdk": "4.2.3",
     "@affinidi/affinity-metrics-lib": "0.0.25",
     "@sentry/browser": "^5.18.0",
     "bip32": "^2.0.5",

--- a/sdk/browser/src/AffinityWallet.ts
+++ b/sdk/browser/src/AffinityWallet.ts
@@ -178,6 +178,23 @@ export class AffinityWallet extends CoreNetwork {
   }
 
   /**
+   * @description Retrieve only the credential at given index
+   * @param credentialIndex - index for the VC in vault
+   * @returns a single VC
+   */
+  async getCredentialByIndex(credentialIndex: number): Promise<any> {
+    const paginationOptions: FetchCredentialsPaginationOptions = { skip: credentialIndex, limit: 1 }
+    const blobs = await this.walletStorageService.fetchEncryptedCredentials(paginationOptions)
+
+    if (blobs.length < 1) {
+      throw new SdkError('COR-14')
+    }
+
+    const decryptedCredentials = await this.walletStorageService.decryptCredentials(blobs)
+    return decryptedCredentials[0]
+  }
+
+  /**
    * @description Finds the given credentialShareRequestToken by searching all of your credentials
    * If a token is not given, only returns the given subset of the credentials
    * 1. pull encrypted VCs (all if token given, otherwise with the given pagination)
@@ -233,7 +250,7 @@ export class AffinityWallet extends CoreNetwork {
    * @param id - id of the credential
    * @param credentialIndex - credential to remove
    */
-  async deleteCredential(id: string, credentialIndex?: any): Promise<void> {
+  async deleteCredential(id: string, credentialIndex?: string): Promise<void> {
     if (credentialIndex !== undefined && id) {
       throw new SdkError('COR-1', {
         errors: [{ message: 'can not define both id and credentialIndex at the same time' }],

--- a/sdk/browser/src/AffinityWallet.ts
+++ b/sdk/browser/src/AffinityWallet.ts
@@ -4,6 +4,7 @@ import { EventComponent } from '@affinidi/affinity-metrics-lib'
 import KeysService from './services/KeysService'
 import WalletStorageService from './services/WalletStorageService'
 import { FetchCredentialsPaginationOptions } from '@affinidi/wallet-core-sdk/dist/dto/shared.dto'
+import { MessageParameters } from '@affinidi/wallet-core-sdk/dist/dto'
 
 type SdkOptions = __dangerous.SdkOptions & {
   issueSignupCredential?: boolean
@@ -47,6 +48,34 @@ export class AffinityWallet extends CoreNetwork {
     const encryptionKey = await WalletStorageService.pullEncryptionKey(accessToken)
 
     return new AffinityWallet(encryptionKey, encryptedSeed, options)
+  }
+
+  /**
+   * @description Initiates sign up flow
+   * @param username - arbitrary username, email or phoneNumber
+   * @param password - is required if arbitrary username was provided.
+   * It is optional and random one will be generated, if not provided when
+   * email or phoneNumber was given as a username.
+   * @param options - optional parameters with specified environment
+   * @param messageParameters - optional parameters with specified welcome message
+   * @returns token or, in case when arbitrary username was used, it returns
+   * initialized instance of SDK
+   */
+  static async signUp(
+    username: string,
+    password?: string,
+    options?: SdkOptions,
+    messageParameters?: MessageParameters,
+  ): Promise<string | any> {
+    const networkMember = await CoreNetwork.signUp(username, password, options, messageParameters)
+
+    if (networkMember.constructor === String) {
+      return networkMember
+    }
+
+    const { password: networkMemberPassword, encryptedSeed } = networkMember
+
+    return new AffinityWallet(networkMemberPassword, encryptedSeed, options)
   }
 
   /**

--- a/sdk/browser/src/AffinityWallet.ts
+++ b/sdk/browser/src/AffinityWallet.ts
@@ -249,15 +249,15 @@ export class AffinityWallet extends CoreNetwork {
    * @param id - id of the credential
    * @param credentialIndex - credential to remove
    */
-  async deleteCredential(id: string, credentialIndex?: string): Promise<void> {
-    if (credentialIndex !== undefined && id) {
+  async deleteCredential(id?: string, credentialIndex?: number): Promise<void> {
+    if ((credentialIndex !== undefined && id) || (!id && credentialIndex === undefined)) {
       throw new __dangerous.SdkError('COR-1', {
-        errors: [{ message: 'can not pass both id and credentialIndex at the same time' }],
+        errors: [{ message: 'should pass either id or credentialIndex and not both at the same time' }],
       })
     }
 
     if (credentialIndex) {
-      return this.deleteCredentialByIndex(credentialIndex)
+      return this.deleteCredentialByIndex(credentialIndex.toString())
     }
 
     let allBlobs: any[] = []

--- a/sdk/browser/src/AffinityWallet.ts
+++ b/sdk/browser/src/AffinityWallet.ts
@@ -4,7 +4,6 @@ import { EventComponent } from '@affinidi/affinity-metrics-lib'
 import KeysService from './services/KeysService'
 import WalletStorageService from './services/WalletStorageService'
 import { FetchCredentialsPaginationOptions } from '@affinidi/wallet-core-sdk/dist/dto/shared.dto'
-import SdkError from '@affinidi/wallet-core-sdk/dist/shared/SdkError'
 
 type SdkOptions = __dangerous.SdkOptions & {
   issueSignupCredential?: boolean
@@ -187,7 +186,7 @@ export class AffinityWallet extends CoreNetwork {
     const blobs = await this.walletStorageService.fetchEncryptedCredentials(paginationOptions)
 
     if (blobs.length < 1) {
-      throw new SdkError('COR-14')
+      throw new __dangerous.SdkError('COR-14')
     }
 
     const decryptedCredentials = await this.walletStorageService.decryptCredentials(blobs)
@@ -237,9 +236,9 @@ export class AffinityWallet extends CoreNetwork {
     for await (const blobs of this.walletStorageService.fetchAllEncryptedCredentialsInBatches()) {
       const credentials = await this.walletStorageService.decryptCredentials(blobs)
 
-      const encryptedCredentials = this.walletStorageService.filterCredentials(credentialShareRequestToken, credentials)
+      const matchedCredentials = this.walletStorageService.filterCredentials(credentialShareRequestToken, credentials)
 
-      result = result.concat(encryptedCredentials)
+      result = result.concat(matchedCredentials)
     }
 
     return result
@@ -252,8 +251,8 @@ export class AffinityWallet extends CoreNetwork {
    */
   async deleteCredential(id: string, credentialIndex?: string): Promise<void> {
     if (credentialIndex !== undefined && id) {
-      throw new SdkError('COR-1', {
-        errors: [{ message: 'can not define both id and credentialIndex at the same time' }],
+      throw new __dangerous.SdkError('COR-1', {
+        errors: [{ message: 'can not pass both id and credentialIndex at the same time' }],
       })
     }
 

--- a/sdk/browser/src/AffinityWallet.ts
+++ b/sdk/browser/src/AffinityWallet.ts
@@ -3,6 +3,7 @@ import { EventComponent } from '@affinidi/affinity-metrics-lib'
 
 import KeysService from './services/KeysService'
 import WalletStorageService from './services/WalletStorageService'
+import { FetchCredentialsPaginationOptions } from '@affinidi/wallet-core-sdk/dist/dto/shared.dto'
 
 type SdkOptions = __dangerous.SdkOptions & {
   issueSignupCredential?: boolean
@@ -176,19 +177,23 @@ export class AffinityWallet extends CoreNetwork {
   }
 
   /**
-   * @description Pulls all credentials which match by credentialShareRequestToken,
-   *   if token not provided all your VCs will be returned:
-   * 1. pull encrypted VCs
+   * @description Pulls a subset of your credentials to find a credential which matches the credentialShareRequestToken,
+   *   if token not provided the whole subset of VCs will be returned:
+   * 1. pull encrypted VCs (with given pagination or the first 100)
    * 2. decrypt encrypted VCs
    * 3. filter VCs by type
    * @param credentialShareRequestToken - JWT received from verifier
+   * @param paginationOptions - optional range for credentials to be pulled (default is skip: 0, limit: 100)
    * @returns array of VCs
    */
-  async getCredentials(credentialShareRequestToken: string = null): Promise<any> {
+  async getCredentials(
+    credentialShareRequestToken: string = null,
+    paginationOptions?: FetchCredentialsPaginationOptions,
+  ): Promise<any> {
     let blobs
 
     try {
-      blobs = await this.walletStorageService.fetchEncryptedCredentials()
+      blobs = await this.walletStorageService.fetchEncryptedCredentials(paginationOptions)
     } catch (error) {
       if (error.code === 'COR-14') {
         return []
@@ -209,14 +214,15 @@ export class AffinityWallet extends CoreNetwork {
   }
 
   /**
-   * @description Delete credential by id
+   * @description Delete credential by id if found in given range
    * @param id - id of the credential
+   * @param paginationOptions - range for pulling the credentials (default is skip: 0, limit: 100)
    */
-  async deleteCredential(id: string): Promise<void> {
+  async deleteCredential(id: string, paginationOptions?: FetchCredentialsPaginationOptions): Promise<void> {
     let blobs
 
     try {
-      blobs = await this.walletStorageService.fetchEncryptedCredentials()
+      blobs = await this.walletStorageService.fetchEncryptedCredentials(paginationOptions)
     } catch (error) {
       if (error.code === 'COR-14') {
         throw new __dangerous.SdkError('COR-14')

--- a/sdk/browser/test/integration/AffinityWallet.test.ts
+++ b/sdk/browser/test/integration/AffinityWallet.test.ts
@@ -165,4 +165,25 @@ describe('AffinityWallet', () => {
 
     expect(credentials).to.exist
   })
+
+  it('#signUp when user registers with arbitrary username', async () => {
+    const generateUsername = () => {
+      const TIMESTAMP = Date.now().toString(16).toUpperCase()
+      return `test.user-${TIMESTAMP}`
+    }
+
+    const cognitoUsername = generateUsername()
+
+    let networkMember
+    networkMember = await AffinityWallet.signUp(cognitoUsername, cognitoPassword, options)
+
+    expect(networkMember.did).to.exist
+    expect(networkMember).to.be.an.instanceof(AffinityWallet)
+
+    await networkMember.signOut()
+
+    networkMember = await AffinityWallet.fromLoginAndPassword(cognitoUsername, cognitoPassword, options)
+
+    expect(networkMember).to.be.an.instanceof(AffinityWallet)
+  })
 })

--- a/sdk/browser/test/unit/AffinityWallet.test.ts
+++ b/sdk/browser/test/unit/AffinityWallet.test.ts
@@ -75,7 +75,7 @@ describe('AffinityWallet', () => {
       expect(code).to.eql('COR-14')
     })
 
-    it('#getCredentials throws error', async () => {
+    it('throws error', async () => {
       const error = 'Error'
 
       sinon.stub(WalletStorageService.prototype, 'fetchEncryptedCredentials').rejects({ code: error })

--- a/sdk/browser/test/unit/AffinityWallet.test.ts
+++ b/sdk/browser/test/unit/AffinityWallet.test.ts
@@ -96,6 +96,52 @@ describe('AffinityWallet', () => {
     })
   })
 
+  describe('#deleteCredential', () => {
+    it('should throw if both parameters are given', async () => {
+      const affinityWallet = new AffinityWallet(walletPassword, encryptedSeed)
+
+      let responseError
+
+      try {
+        await affinityWallet.deleteCredential('id', 1)
+      } catch (error) {
+        responseError = error
+      }
+
+      const { code } = responseError
+
+      expect(code).to.eql('COR-1')
+    })
+
+    it('should throw if neither parameters are given', async () => {
+      const affinityWallet = new AffinityWallet(walletPassword, encryptedSeed)
+
+      let responseError
+
+      try {
+        await affinityWallet.deleteCredential(undefined, undefined)
+      } catch (error) {
+        responseError = error
+      }
+
+      const { code } = responseError
+
+      expect(code).to.eql('COR-1')
+    })
+
+    it('should remove with given index', async () => {
+      const credentialIndex = 1
+
+      sinon.stub(CommonNetworkMember.prototype as any, 'deleteCredentialByIndex').resolves(undefined)
+
+      const affinityWallet = new AffinityWallet(walletPassword, encryptedSeed)
+
+      const result = await affinityWallet.deleteCredential(undefined, credentialIndex)
+
+      expect(result).to.be.undefined
+    })
+  })
+
   it('#getCredentials returns [] if there are no credentials for the user', async () => {
     sinon.stub(WalletStorageService.prototype, 'fetchEncryptedCredentials').rejects({ code: 'COR-14' })
 

--- a/sdk/browser/test/unit/AffinityWallet.test.ts
+++ b/sdk/browser/test/unit/AffinityWallet.test.ts
@@ -56,6 +56,46 @@ describe('AffinityWallet', () => {
     sinon.restore()
   })
 
+  describe('#getCredentialByIndex', () => {
+    it('throws COR-14 if there are no credentials for the user', async () => {
+      sinon.stub(WalletStorageService.prototype, 'fetchEncryptedCredentials').resolves([])
+
+      const affinityWallet = new AffinityWallet(walletPassword, encryptedSeed)
+
+      let responseError
+
+      try {
+        await affinityWallet.getCredentialByIndex(0)
+      } catch (error) {
+        responseError = error
+      }
+
+      const { code } = responseError
+
+      expect(code).to.eql('COR-14')
+    })
+
+    it('#getCredentials throws error', async () => {
+      const error = 'Error'
+
+      sinon.stub(WalletStorageService.prototype, 'fetchEncryptedCredentials').rejects({ code: error })
+
+      const affinityWallet = new AffinityWallet(walletPassword, encryptedSeed)
+
+      let responseError
+
+      try {
+        await affinityWallet.getCredentialByIndex(0)
+      } catch (error) {
+        responseError = error
+      }
+
+      const { code } = responseError
+
+      expect(code).to.eql(error)
+    })
+  })
+
   it('#getCredentials returns [] if there are no credentials for the user', async () => {
     sinon.stub(WalletStorageService.prototype, 'fetchEncryptedCredentials').rejects({ code: 'COR-14' })
 

--- a/sdk/core/CHANGELOG.md
+++ b/sdk/core/CHANGELOG.md
@@ -1,6 +1,7 @@
 # release 4.2.3 (2020-04-01)
  * add optional pagination to `WalletStorageService.fetchEncryptedCredentials` (backward compatible)
  * add new `WalletStorageService.fetchAllEncryptedCredentialsInBatches` method for retrieving all credentials page by page using async generators
+ * fix elem did anchor metrics blocks flow in case of failure
 # release 4.2.2 
  * use new `vc-data` 
 # release 4.2.1 (2020-02-22)

--- a/sdk/core/CHANGELOG.md
+++ b/sdk/core/CHANGELOG.md
@@ -1,3 +1,6 @@
+# release 4.2.3 (2020-04-01)
+ * add optional pagination to `WalletStorageService.fetchEncryptedCredentials` (backward compatible)
+ * add new `WalletStorageService.fetchAllEncryptedCredentialsInBatches` method for retrieving all credentials page by page using async generators
 # release 4.2.2 
  * use new `vc-data` 
 # release 4.2.1 (2020-02-22)

--- a/sdk/core/package-lock.json
+++ b/sdk/core/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@affinidi/wallet-core-sdk",
-	"version": "4.2.2",
+	"version": "4.2.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/sdk/core/package.json
+++ b/sdk/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@affinidi/wallet-core-sdk",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "description": "SDK core monorepo for affinity DID solution",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/sdk/core/src/CommonNetworkMember.ts
+++ b/sdk/core/src/CommonNetworkMember.ts
@@ -480,7 +480,7 @@ export class CommonNetworkMember {
     // NOTE: for metrics purpose in case of ELEM method
     if (didMethod === ELEM_DID_METHOD) {
       try {
-        api.execute('registry.AnchorDid', {
+        await api.execute('registry.AnchorDid', {
           params: { did, didDocumentAddress: '', ethereumPublicKeyHex: '', transactionSignatureJson: '' },
         })
       } catch (error) {

--- a/sdk/core/src/dto/shared.dto.ts
+++ b/sdk/core/src/dto/shared.dto.ts
@@ -12,6 +12,8 @@ import {
   IsJWT,
   Matches,
   IsIn,
+  IsInt,
+  Min,
 } from 'class-validator'
 
 import { FreeFormObject } from '../shared/interfaces'
@@ -338,4 +340,16 @@ export class SignCredentialOptionalInput {
   @IsOptional()
   @IsJWT()
   credentialOfferResponseToken?: string
+}
+
+export class FetchCredentialsPaginationOptions {
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  skip?: number
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  limit?: number
 }

--- a/sdk/core/src/services/WalletStorageService.ts
+++ b/sdk/core/src/services/WalletStorageService.ts
@@ -348,7 +348,7 @@ export default class WalletStorageService {
       },
     ])
 
-    const paginationOptions = WalletStorageService.getPaginationOptionsWithDefault(fetchCredentialsPaginationOptions)
+    const paginationOptions = WalletStorageService._getPaginationOptionsWithDefault(fetchCredentialsPaginationOptions)
 
     return this._fetchEncryptedCredentialsWithPagination(paginationOptions)
   }
@@ -369,11 +369,21 @@ export default class WalletStorageService {
       },
     ])
 
-    const paginationOptions = WalletStorageService.getPaginationOptionsWithDefault(fetchCredentialsPaginationOptions)
+    const paginationOptions = WalletStorageService._getPaginationOptionsWithDefault(fetchCredentialsPaginationOptions)
     let lastCount = 0
 
     do {
-      const blobs = await this._fetchEncryptedCredentialsWithPagination(paginationOptions)
+      let blobs: any[] = []
+
+      try {
+        blobs = await this._fetchEncryptedCredentialsWithPagination(paginationOptions)
+      } catch (err) {
+        if (err.code === 'COR-14') {
+          break
+        }
+
+        throw err
+      }
 
       yield blobs
 
@@ -504,7 +514,7 @@ export default class WalletStorageService {
     return signedCredentials
   }
 
-  private static getPaginationOptionsWithDefault(
+  private static _getPaginationOptionsWithDefault(
     fetchCredentialsPaginationOptions?: FetchCredentialsPaginationOptions,
   ): PaginationOptions {
     const { skip, limit } = fetchCredentialsPaginationOptions || {}

--- a/sdk/core/test/helpers/authorizeVault.ts
+++ b/sdk/core/test/helpers/authorizeVault.ts
@@ -47,3 +47,21 @@ export const authorizeVault = async () => {
 
   return token
 }
+
+export const authorizeVaultEndpoints = async () => {
+  const token = 'token'
+  const requestTokenPath = '/auth/request-token'
+  const validateTokenPath = '/auth/validate-token'
+
+  nock(STAGING_VAULT_URL)
+    .filteringPath(() => requestTokenPath)
+    .post(requestTokenPath)
+    .reply(200, { token })
+
+  nock(STAGING_VAULT_URL)
+    .filteringPath(() => validateTokenPath)
+    .post(validateTokenPath)
+    .reply(200, {})
+
+  return token
+}

--- a/sdk/expo/CHANGELOG.md
+++ b/sdk/expo/CHANGELOG.md
@@ -1,3 +1,6 @@
+# release 4.2.3 (2020-04-01)
+* add optional pagination to `AffinityWallet.getCredentials`
+* add new method `AffinityWallet.getCredentialByIndex` that returns credentials given at the index
 # release 4.2.2 
  * use new `vc-data` 
 # release 4.2.1 (2020-02-22)

--- a/sdk/expo/CHANGELOG.md
+++ b/sdk/expo/CHANGELOG.md
@@ -1,6 +1,7 @@
 # release 4.2.3 (2020-04-01)
-* add optional pagination to `AffinityWallet.getCredentials`
-* add new method `AffinityWallet.getCredentialByIndex` that returns credentials given at the index
+ * add optional pagination to `AffinityWallet.getCredentials`
+ * add new method `AffinityWallet.getCredentialByIndex` that returns credentials given at the index
+ * fix `AffinityWallet.signUp` returning CommonNetworkMember instead of Expo AffinityWallet
 # release 4.2.2 
  * use new `vc-data` 
 # release 4.2.1 (2020-02-22)

--- a/sdk/expo/package-lock.json
+++ b/sdk/expo/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@affinidi/wallet-expo-sdk",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/sdk/expo/package.json
+++ b/sdk/expo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@affinidi/wallet-expo-sdk",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "description": "SDK monorepo for affinity DID solution for Expo",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -41,7 +41,7 @@
   "license": "ISC",
   "dependencies": {
     "@affinidi/common": "1.6.0",
-    "@affinidi/wallet-core-sdk": "4.2.2",
+    "@affinidi/wallet-core-sdk": "4.2.3",
     "@affinidi/affinity-metrics-lib": "0.0.25",
     "@react-native-community/netinfo": "^5.5.1",
     "@types/text-encoding": "0.0.35",

--- a/sdk/expo/src/AffinityWallet.ts
+++ b/sdk/expo/src/AffinityWallet.ts
@@ -3,6 +3,7 @@ import { EventComponent } from '@affinidi/affinity-metrics-lib'
 
 import KeysService from './services/KeysService'
 import WalletStorageService from './services/WalletStorageService'
+import { FetchCredentialsPaginationOptions } from '@affinidi/wallet-core-sdk/dist/dto/shared.dto'
 import { profile } from '@affinidi/common'
 
 type SdkOptions = __dangerous.SdkOptions & {
@@ -199,18 +200,20 @@ export class AffinityWallet extends CoreNetwork {
   }
 
   /**
-   * @description Pulls all credentials which match by credentialShareRequestToken,
-   *   if token not provided all your VCs will be returned:
-   * 1. pull encrypted VCs
+   * @description Pulls a subset of your credentials to find a credential which matches the credentialShareRequestToken,
+   *   if token not provided the whole subset of VCs will be returned:
+   * 1. pull encrypted VCs (with given pagination or the first 100)
    * 2. decrypt encrypted VCs
    * 3. filter VCs by type
    * @param credentialShareRequestToken - JWT received from verifier
    * @param fetchBackupCredentials - optional, if false - return credentials from instance
+   * @param paginationOptions - optional range for credentials to be pulled (default is skip: 0, limit: 100)
    * @returns array of VCs
    */
   async getCredentials(
     credentialShareRequestToken: string = null,
     fetchBackupCredentials: boolean = true,
+    paginationOptions?: FetchCredentialsPaginationOptions,
   ): Promise<any> {
     let blobs
 
@@ -218,7 +221,7 @@ export class AffinityWallet extends CoreNetwork {
 
     if (fetchBackupCredentials) {
       try {
-        blobs = await this.walletStorageService.fetchEncryptedCredentials()
+        blobs = await this.walletStorageService.fetchEncryptedCredentials(paginationOptions)
       } catch (error) {
         if (error.code === 'COR-14') {
           return []
@@ -240,14 +243,15 @@ export class AffinityWallet extends CoreNetwork {
   }
 
   /**
-   * @description Delete credential by id
+   * @description Delete credential by id if found in given range
    * @param id - id of the credential
+   * @param paginationOptions - range for pulling the credentials (default is skip: 0, limit: 100)
    */
-  async deleteCredential(id: string): Promise<void> {
+  async deleteCredential(id: string, paginationOptions?: FetchCredentialsPaginationOptions): Promise<void> {
     let blobs
 
     try {
-      blobs = await this.walletStorageService.fetchEncryptedCredentials()
+      blobs = await this.walletStorageService.fetchEncryptedCredentials(paginationOptions)
     } catch (error) {
       if (error.code === 'COR-14') {
         throw new __dangerous.SdkError('COR-14')

--- a/sdk/expo/src/AffinityWallet.ts
+++ b/sdk/expo/src/AffinityWallet.ts
@@ -5,6 +5,7 @@ import KeysService from './services/KeysService'
 import WalletStorageService from './services/WalletStorageService'
 import { FetchCredentialsPaginationOptions } from '@affinidi/wallet-core-sdk/dist/dto/shared.dto'
 import { profile } from '@affinidi/common'
+import { MessageParameters } from '@affinidi/wallet-core-sdk/dist/dto'
 
 type SdkOptions = __dangerous.SdkOptions & {
   issueSignupCredential?: boolean
@@ -65,6 +66,34 @@ export class AffinityWallet extends CoreNetwork {
     const encryptionKey = await WalletStorageService.pullEncryptionKey(accessToken)
 
     return new AffinityWallet(encryptionKey, encryptedSeed, options)
+  }
+
+  /**
+   * @description Initiates sign up flow
+   * @param username - arbitrary username, email or phoneNumber
+   * @param password - is required if arbitrary username was provided.
+   * It is optional and random one will be generated, if not provided when
+   * email or phoneNumber was given as a username.
+   * @param options - optional parameters with specified environment
+   * @param messageParameters - optional parameters with specified welcome message
+   * @returns token or, in case when arbitrary username was used, it returns
+   * initialized instance of SDK
+   */
+  static async signUp(
+    username: string,
+    password?: string,
+    options?: SdkOptions,
+    messageParameters?: MessageParameters,
+  ): Promise<string | any> {
+    const networkMember = await CoreNetwork.signUp(username, password, options, messageParameters)
+
+    if (networkMember.constructor === String) {
+      return networkMember
+    }
+
+    const { password: networkMemberPassword, encryptedSeed } = networkMember
+
+    return new AffinityWallet(networkMemberPassword, encryptedSeed, options)
   }
 
   /**

--- a/sdk/expo/test/integration/AffinityWallet.test.ts
+++ b/sdk/expo/test/integration/AffinityWallet.test.ts
@@ -163,4 +163,25 @@ describe('AffinityWallet', () => {
 
     expect(credentials).to.exist
   })
+
+  it('#signUp when user registers with arbitrary username', async () => {
+    const generateUsername = () => {
+      const TIMESTAMP = Date.now().toString(16).toUpperCase()
+      return `test.user-${TIMESTAMP}`
+    }
+
+    const cognitoUsername = generateUsername()
+
+    let networkMember
+    networkMember = await AffinityWallet.signUp(cognitoUsername, cognitoPassword, options)
+
+    expect(networkMember.did).to.exist
+    expect(networkMember).to.be.an.instanceof(AffinityWallet)
+
+    await networkMember.signOut()
+
+    networkMember = await AffinityWallet.fromLoginAndPassword(cognitoUsername, cognitoPassword, options)
+
+    expect(networkMember).to.be.an.instanceof(AffinityWallet)
+  })
 })

--- a/sdk/expo/test/unit/AffinityWallet.test.ts
+++ b/sdk/expo/test/unit/AffinityWallet.test.ts
@@ -56,6 +56,46 @@ describe('AffinityWallet', () => {
     sinon.restore()
   })
 
+  describe('#getCredentialByIndex', () => {
+    it('throws COR-14 if there are no credentials for the user', async () => {
+      sinon.stub(WalletStorageService.prototype, 'fetchEncryptedCredentials').resolves([])
+
+      const affinityWallet = new AffinityWallet(walletPassword, encryptedSeed)
+
+      let responseError
+
+      try {
+        await affinityWallet.getCredentialByIndex(0)
+      } catch (error) {
+        responseError = error
+      }
+
+      const { code } = responseError
+
+      expect(code).to.eql('COR-14')
+    })
+
+    it('throws error', async () => {
+      const error = 'Error'
+
+      sinon.stub(WalletStorageService.prototype, 'fetchEncryptedCredentials').rejects({ code: error })
+
+      const affinityWallet = new AffinityWallet(walletPassword, encryptedSeed)
+
+      let responseError
+
+      try {
+        await affinityWallet.getCredentialByIndex(0)
+      } catch (error) {
+        responseError = error
+      }
+
+      const { code } = responseError
+
+      expect(code).to.eql(error)
+    })
+  })
+
   it('#getCredentials returns [] if there are no credentials for the user', async () => {
     sinon.stub(WalletStorageService.prototype, 'fetchEncryptedCredentials').rejects({ code: 'COR-14' })
 

--- a/sdk/react-native/CHANGELOG.md
+++ b/sdk/react-native/CHANGELOG.md
@@ -1,3 +1,6 @@
+# release 4.2.3 (2020-04-01)
+* add optional pagination to `AffinityWallet.getCredentials`
+* add new method `AffinityWallet.getCredentialByIndex` that returns credentials given at the index
 # release 4.2.2 
  * use new `vc-data`
 # release 4.2.1 (2020-02-22)

--- a/sdk/react-native/CHANGELOG.md
+++ b/sdk/react-native/CHANGELOG.md
@@ -1,6 +1,7 @@
 # release 4.2.3 (2020-04-01)
-* add optional pagination to `AffinityWallet.getCredentials`
-* add new method `AffinityWallet.getCredentialByIndex` that returns credentials given at the index
+ * add optional pagination to `AffinityWallet.getCredentials`
+ * add new method `AffinityWallet.getCredentialByIndex` that returns credentials given at the index
+ * fix `AffinityWallet.signUp` returning CommonNetworkMember instead of React Native AffinityWallet
 # release 4.2.2 
  * use new `vc-data`
 # release 4.2.1 (2020-02-22)

--- a/sdk/react-native/package-lock.json
+++ b/sdk/react-native/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@affinidi/wallet-react-native-sdk",
-	"version": "4.2.2",
+	"version": "4.2.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/sdk/react-native/package.json
+++ b/sdk/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@affinidi/wallet-react-native-sdk",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "description": "SDK for affinity DID solution for React Native",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -34,7 +34,7 @@
   "license": "ISC",
   "dependencies": {
     "@affinidi/common": "1.6.0",
-    "@affinidi/wallet-core-sdk": "4.2.2",
+    "@affinidi/wallet-core-sdk": "4.2.3",
     "@affinidi/affinity-metrics-lib": "0.0.25",
     "@react-native-community/netinfo": "^5.9.3",
     "@sentry/react-native": "^1.5.0",

--- a/sdk/react-native/src/AffinityWallet.ts
+++ b/sdk/react-native/src/AffinityWallet.ts
@@ -5,6 +5,7 @@ import KeysService from './services/KeysService'
 import WalletStorageService from './services/WalletStorageService'
 import { FetchCredentialsPaginationOptions } from '@affinidi/wallet-core-sdk/dist/dto/shared.dto'
 import { profile } from '@affinidi/common'
+import { MessageParameters } from '@affinidi/wallet-core-sdk/dist/dto'
 
 type SdkOptions = __dangerous.SdkOptions & {
   issueSignupCredential?: boolean
@@ -65,6 +66,34 @@ export class AffinityWallet extends CoreNetwork {
     const encryptionKey = await WalletStorageService.pullEncryptionKey(accessToken)
 
     return new AffinityWallet(encryptionKey, encryptedSeed, options)
+  }
+
+  /**
+   * @description Initiates sign up flow
+   * @param username - arbitrary username, email or phoneNumber
+   * @param password - is required if arbitrary username was provided.
+   * It is optional and random one will be generated, if not provided when
+   * email or phoneNumber was given as a username.
+   * @param options - optional parameters with specified environment
+   * @param messageParameters - optional parameters with specified welcome message
+   * @returns token or, in case when arbitrary username was used, it returns
+   * initialized instance of SDK
+   */
+  static async signUp(
+    username: string,
+    password?: string,
+    options?: SdkOptions,
+    messageParameters?: MessageParameters,
+  ): Promise<string | any> {
+    const networkMember = await CoreNetwork.signUp(username, password, options, messageParameters)
+
+    if (networkMember.constructor === String) {
+      return networkMember
+    }
+
+    const { password: networkMemberPassword, encryptedSeed } = networkMember
+
+    return new AffinityWallet(networkMemberPassword, encryptedSeed, options)
   }
 
   /**

--- a/sdk/react-native/src/AffinityWallet.ts
+++ b/sdk/react-native/src/AffinityWallet.ts
@@ -199,14 +199,32 @@ export class AffinityWallet extends CoreNetwork {
   }
 
   /**
-   * @description Pulls a subset of your credentials to find a credential which matches the credentialShareRequestToken,
-   *   if token not provided the whole subset of VCs will be returned:
-   * 1. pull encrypted VCs (with given pagination or the first 100)
+   * @description Retrieve only the credential at given index
+   * @param credentialIndex - index for the VC in vault
+   * @returns a single VC
+   */
+  async getCredentialByIndex(credentialIndex: number): Promise<any> {
+    const paginationOptions: FetchCredentialsPaginationOptions = { skip: credentialIndex, limit: 1 }
+    const blobs = await this.walletStorageService.fetchEncryptedCredentials(paginationOptions)
+
+    if (blobs.length < 1) {
+      throw new __dangerous.SdkError('COR-14')
+    }
+
+    const decryptedCredentials = await this.walletStorageService.decryptCredentials(blobs)
+    return decryptedCredentials[0]
+  }
+
+  /**
+   * @description Searches all of VCs for matches for the given credentialShareRequestToken
+   *   or returns all of your offline VCs
+   *   or fetches a subset of backup VCs
+   * 1. pull encrypted VCs
    * 2. decrypt encrypted VCs
-   * 3. filter VCs by type
-   * @param credentialShareRequestToken - JWT received from verifier
-   * @param fetchBackupCredentials - optional, if false - return credentials from instance
-   * @param paginationOptions - optional range for credentials to be pulled (default is skip: 0, limit: 100)
+   * 3. optionally filter VCs by type
+   * @param credentialShareRequestToken - JWT received from verifier, if given will search in all VCs
+   * @param fetchBackupCredentials - optional, if false - returns all credentials from instance ignoring pagination
+   * @param paginationOptions - if fetching from backup, optional range for credentials to be pulled (default is skip: 0, limit: 100)
    * @returns array of VCs
    */
   async getCredentials(
@@ -214,52 +232,78 @@ export class AffinityWallet extends CoreNetwork {
     fetchBackupCredentials: boolean = true,
     paginationOptions?: FetchCredentialsPaginationOptions,
   ): Promise<any> {
-    let blobs
-
-    let credentials = this._credentials
-
-    if (fetchBackupCredentials) {
-      try {
-        blobs = await this.walletStorageService.fetchEncryptedCredentials(paginationOptions)
-      } catch (error) {
-        if (error.code === 'COR-14') {
-          return []
-        } else {
-          throw error
-        }
-      }
-
-      if (blobs.length === 0) {
-        return []
-      }
-
-      credentials = await this.walletStorageService.decryptCredentials(blobs)
-
-      this._credentials = credentials
+    if (!fetchBackupCredentials) {
+      return this.walletStorageService.filterCredentials(credentialShareRequestToken, this._credentials)
     }
 
-    return this.walletStorageService.filterCredentials(credentialShareRequestToken, credentials)
+    if (credentialShareRequestToken) {
+      return this._getCredentialsWithCredentialShareRequestToken(credentialShareRequestToken)
+    }
+
+    return this._fetchCredentialsWithPagination(paginationOptions)
   }
 
-  /**
-   * @description Delete credential by id if found in given range
-   * @param id - id of the credential
-   * @param paginationOptions - range for pulling the credentials (default is skip: 0, limit: 100)
-   */
-  async deleteCredential(id: string, paginationOptions?: FetchCredentialsPaginationOptions): Promise<void> {
+  private async _fetchCredentialsWithPagination(paginationOptions?: FetchCredentialsPaginationOptions): Promise<any[]> {
     let blobs
 
     try {
       blobs = await this.walletStorageService.fetchEncryptedCredentials(paginationOptions)
     } catch (error) {
       if (error.code === 'COR-14') {
-        throw new __dangerous.SdkError('COR-14')
+        return []
       } else {
         throw error
       }
     }
 
-    await this.walletStorageService.decryptCredentials(blobs)
+    if (blobs.length === 0) {
+      return []
+    }
+
+    return this.walletStorageService.decryptCredentials(blobs)
+  }
+
+  private async _getCredentialsWithCredentialShareRequestToken(credentialShareRequestToken: string): Promise<any> {
+    let allCredentials: any[] = []
+    let result: any[] = []
+
+    for await (const blobs of this.walletStorageService.fetchAllEncryptedCredentialsInBatches()) {
+      const credentials = await this.walletStorageService.decryptCredentials(blobs)
+
+      const matchedCredentials = this.walletStorageService.filterCredentials(credentialShareRequestToken, credentials)
+
+      allCredentials = allCredentials.concat(credentials)
+      result = result.concat(matchedCredentials)
+    }
+
+    this._credentials = allCredentials
+
+    return result
+  }
+
+  /**
+   * @description Delete credential by id if found in given range
+   * @param id - id of the credential
+   * @param credentialIndex - credential to remove
+   */
+  async deleteCredential(id: string, credentialIndex?: string): Promise<void> {
+    if (credentialIndex !== undefined && id) {
+      throw new __dangerous.SdkError('COR-1', {
+        errors: [{ message: 'can not pass both id and credentialIndex at the same time' }],
+      })
+    }
+
+    if (credentialIndex) {
+      return this.deleteCredentialByIndex(credentialIndex)
+    }
+
+    let allBlobs: any[] = []
+
+    for await (const blobs of this.walletStorageService.fetchAllEncryptedCredentialsInBatches()) {
+      allBlobs = allBlobs.concat(blobs)
+    }
+
+    await this.walletStorageService.decryptCredentials(allBlobs)
 
     const credentialIndexToDelete = this.walletStorageService.findCredentialIndexById(id)
 

--- a/sdk/react-native/test/integration/AffinityWallet.test.ts
+++ b/sdk/react-native/test/integration/AffinityWallet.test.ts
@@ -159,4 +159,25 @@ describe('AffinityWallet', () => {
 
     expect(credentials).to.exist
   })
+
+  it('#signUp when user registers with arbitrary username', async () => {
+    const generateUsername = () => {
+      const TIMESTAMP = Date.now().toString(16).toUpperCase()
+      return `test.user-${TIMESTAMP}`
+    }
+
+    const cognitoUsername = generateUsername()
+
+    let networkMember
+    networkMember = await AffinityWallet.signUp(cognitoUsername, cognitoPassword, options)
+
+    expect(networkMember.did).to.exist
+    expect(networkMember).to.be.an.instanceof(AffinityWallet)
+
+    await networkMember.signOut()
+
+    networkMember = await AffinityWallet.fromLoginAndPassword(cognitoUsername, cognitoPassword, options)
+
+    expect(networkMember).to.be.an.instanceof(AffinityWallet)
+  })
 })

--- a/sdk/react-native/test/unit/AffinityWallet.test.ts
+++ b/sdk/react-native/test/unit/AffinityWallet.test.ts
@@ -56,6 +56,46 @@ describe('AffinityWallet', () => {
     sinon.restore()
   })
 
+  describe('#getCredentialByIndex', () => {
+    it('throws COR-14 if there are no credentials for the user', async () => {
+      sinon.stub(WalletStorageService.prototype, 'fetchEncryptedCredentials').resolves([])
+
+      const affinityWallet = new AffinityWallet(walletPassword, encryptedSeed)
+
+      let responseError
+
+      try {
+        await affinityWallet.getCredentialByIndex(0)
+      } catch (error) {
+        responseError = error
+      }
+
+      const { code } = responseError
+
+      expect(code).to.eql('COR-14')
+    })
+
+    it('throws error', async () => {
+      const error = 'Error'
+
+      sinon.stub(WalletStorageService.prototype, 'fetchEncryptedCredentials').rejects({ code: error })
+
+      const affinityWallet = new AffinityWallet(walletPassword, encryptedSeed)
+
+      let responseError
+
+      try {
+        await affinityWallet.getCredentialByIndex(0)
+      } catch (error) {
+        responseError = error
+      }
+
+      const { code } = responseError
+
+      expect(code).to.eql(error)
+    })
+  })
+
   it('#getCredentials returns [] if there are no credentials for the user', async () => {
     sinon.stub(WalletStorageService.prototype, 'fetchEncryptedCredentials').rejects({ code: 'COR-14' })
 


### PR DESCRIPTION
## Pagination
This PR adds pagination to **WalletStorageService** to optimize performance when accessing the bloom vault. Bumped core SDK version. And updated Browser/Expo/ReactNative SDKs to use the new version.

GetCredentials / DeleteCredential use-cases in Browser/Expo/ReactNative SDKs are updated to use the new pagination, optionally.

### Pagination Logic
Bloom Vault's start/end dates are inclusive. So `/data/0/99` means retrieving the first 100 credentials. New added skip/limit parameters need to be 0 and 100 respectively to retrieve these first 100 records. By default, these parameter defaults are 0/100. Some other examples:

```
{} = '/data/0/99'
{ limit: 5 } = '/data/0/4'
{ skip: 1 } = '/data/1/100'
{ skip: 1, limit: 1 } = '/data/1/1' 
```

### Additional
- fix did anchor metrics failing breaks flow
- fix AffinityWallet returning CommonNetworkMember for Browser/Expo/React Native