### PR TITLE
[5.0.1] [FTL-1677] Moved TestmailInbox from __dangerous to test-helpers

### DIFF
--- a/sdk/browser/CHANGELOG.md
+++ b/sdk/browser/CHANGELOG.md
@@ -1,3 +1,5 @@
+# release 5.0.1 (2021-06-21)
+* Removed TestmailInbox from `__dangerous`
 # release 5.0.0 (2021-06-16)
 * `getCredentials` now returns all credentials (even if there are more than 100 of them)
 * Performance optimization

--- a/sdk/browser/CHANGELOG.md
+++ b/sdk/browser/CHANGELOG.md
@@ -1,5 +1,5 @@
 # release 5.0.1 (2021-06-21)
-* Removed TestmailInbox from `__dangerous`
+* Removed TestmailInbox from `__dangerous` to fix unnecessary `crypto-random-string` import
 # release 5.0.0 (2021-06-16)
 * `getCredentials` now returns all credentials (even if there are more than 100 of them)
 * Performance optimization

--- a/sdk/browser/README.md
+++ b/sdk/browser/README.md
@@ -1,5 +1,11 @@
 # Affinity SDK for browser
 
+> Please note that versions `>=4.2.6 <=5.0.0` might not work properly (see [this PR](https://github.com/affinityproject/affinidi-core-sdk/pull/105)).
+> 
+> For `v5`, please use versions `>=5.0.1`.
+> 
+> For `v4`, please use version `4.2.5` or, even better, update to `v5`.
+
 Browser SDK extends CORE SDK. Make sure to check the [CORE SDK documentation](https://www.npmjs.com/package/@affinidi/wallet-core-sdk).
 
 ## How to install

--- a/sdk/browser/package-lock.json
+++ b/sdk/browser/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@affinidi/wallet-browser-sdk",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@affinidi/wallet-browser-sdk",
-      "version": "5.0.0",
+      "version": "5.0.1",
       "license": "ISC",
       "dependencies": {
         "@affinidi/affinity-metrics-lib": "^0.0.25",

--- a/sdk/browser/package.json
+++ b/sdk/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@affinidi/wallet-browser-sdk",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "SDK monorepo for affinity DID solution for browser",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/sdk/browser/test/integration/WalletStorageService.test.ts
+++ b/sdk/browser/test/integration/WalletStorageService.test.ts
@@ -4,6 +4,7 @@ import './env'
 
 import { expect } from 'chai'
 import { __dangerous } from '@affinidi/wallet-core-sdk'
+import { TestmailInbox } from '@affinidi/wallet-core-sdk/dist/test-helpers'
 import { MessageParameters } from '@affinidi/wallet-core-sdk/dist/dto'
 import { AffinityWallet } from '../../src/AffinityWallet'
 
@@ -22,12 +23,12 @@ const messageParameters: MessageParameters = {
   subject: `Verification code`,
 }
 
-const waitForOtpCode = async (inbox: __dangerous.TestmailInbox): Promise<string> => {
+const waitForOtpCode = async (inbox: TestmailInbox): Promise<string> => {
   const { body } = await inbox.waitForNewEmail()
   return body.replace('Your verification code is: ', '')
 }
 
-const createInbox = () => new __dangerous.TestmailInbox({ prefix: env, suffix: 'otp.browser' })
+const createInbox = () => new TestmailInbox({ prefix: env, suffix: 'otp.browser' })
 
 const getCredentialIds = (credentials: any[]) => new Set(credentials.map((credential) => credential.id))
 

--- a/sdk/browser/test/integration/otp/index.test.ts
+++ b/sdk/browser/test/integration/otp/index.test.ts
@@ -4,6 +4,7 @@ import '../env'
 
 import { expect } from 'chai'
 import { __dangerous } from '@affinidi/wallet-core-sdk'
+import { TestmailInbox } from '@affinidi/wallet-core-sdk/dist/test-helpers'
 import { MessageParameters } from '@affinidi/wallet-core-sdk/dist/dto'
 import { AffinityWallet } from '../../../src/AffinityWallet'
 
@@ -36,12 +37,12 @@ const messageParameters: MessageParameters = {
   subject: `Verification code`,
 }
 
-const waitForOtpCode = async (inbox: __dangerous.TestmailInbox): Promise<string> => {
+const waitForOtpCode = async (inbox: TestmailInbox): Promise<string> => {
   const { body } = await inbox.waitForNewEmail()
   return body.replace('Your verification code is: ', '')
 }
 
-const createInbox = () => new __dangerous.TestmailInbox({ prefix: env, suffix: 'otp.browser' })
+const createInbox = () => new TestmailInbox({ prefix: env, suffix: 'otp.browser' })
 
 function checkIsString(value: string | unknown): asserts value is string {
   expect(value).to.be.a('string')

--- a/sdk/core/CHANGELOG.md
+++ b/sdk/core/CHANGELOG.md
@@ -1,3 +1,5 @@
+# release 5.0.1 (2021-06-21)
+  * Removed TestmailInbox from `__dangerous`
 # release 5.0.0 (2021-06-16)
   * Implemented `WalletStorageService.fetchAllBlobs`.
   * Fixed `WalletStorageServices.fetchAllEncryptedCredentialsInBatches` stopping on batches with deleted entries.

--- a/sdk/core/CHANGELOG.md
+++ b/sdk/core/CHANGELOG.md
@@ -1,5 +1,5 @@
 # release 5.0.1 (2021-06-21)
-  * Removed TestmailInbox from `__dangerous`
+  * Removed TestmailInbox from `__dangerous` to fix unnecessary `crypto-random-string` import
 # release 5.0.0 (2021-06-16)
   * Implemented `WalletStorageService.fetchAllBlobs`.
   * Fixed `WalletStorageServices.fetchAllEncryptedCredentialsInBatches` stopping on batches with deleted entries.

--- a/sdk/core/README.md
+++ b/sdk/core/README.md
@@ -1,5 +1,11 @@
 # Affinity Core SDK - Affinity network DID solution
 
+> Please note that versions `>=4.2.6 <=5.0.0` might not work properly (see [this PR](https://github.com/affinityproject/affinidi-core-sdk/pull/105)).
+> 
+> For `v5`, please use versions `>=5.0.1`.
+> 
+> For `v4`, please use version `4.2.5` or, even better, update to `v5`.
+
 ## Table of contents
 
 - [Affinity Core SDK - Affinity network DID solution](#affinidi-core-sdk---affinity-network-did-solution)

--- a/sdk/core/package-lock.json
+++ b/sdk/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@affinidi/wallet-core-sdk",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@affinidi/wallet-core-sdk",
-      "version": "5.0.0",
+      "version": "5.0.1",
       "license": "ISC",
       "dependencies": {
         "@affinidi/affinity-metrics-lib": "^0.0.25",

--- a/sdk/core/package.json
+++ b/sdk/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@affinidi/wallet-core-sdk",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "SDK core monorepo for affinity DID solution",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/sdk/core/src/dangerous.ts
+++ b/sdk/core/src/dangerous.ts
@@ -6,4 +6,3 @@ export { SdkOptions, CognitoUserTokens } from './dto'
 export { SdkError, validateUsername, ParametersValidator, readUserTokensFromSessionStorage } from './shared'
 
 export { isW3cCredential } from './_helpers'
-export { TestmailInbox } from './test-helpers/TestmailInbox'

--- a/sdk/core/src/test-helpers/index.ts
+++ b/sdk/core/src/test-helpers/index.ts
@@ -1,0 +1,1 @@
+export { TestmailInbox } from './TestmailInbox'

--- a/sdk/core/test/integration/otp/index.test.ts
+++ b/sdk/core/test/integration/otp/index.test.ts
@@ -8,7 +8,7 @@ import SdkError from '../../../src/shared/SdkError'
 
 import { generateUsername, getOptionsForEnvironment } from '../../helpers'
 import { MessageParameters } from '../../../dist/dto'
-import { __dangerous } from '../../../dist'
+import { TestmailInbox } from '../../../dist/test-helpers'
 
 const { COGNITO_PASSWORD } = JSON.parse(process.env.TEST_SECRETS)
 
@@ -20,12 +20,12 @@ const messageParameters: MessageParameters = {
   subject: `Verification code`,
 }
 
-const waitForOtpCode = async (inbox: __dangerous.TestmailInbox): Promise<string> => {
+const waitForOtpCode = async (inbox: TestmailInbox): Promise<string> => {
   const { body } = await inbox.waitForNewEmail()
   return body.replace('Your verification code is: ', '')
 }
 
-const createInbox = () => new __dangerous.TestmailInbox({ prefix: env, suffix: 'otp.core' })
+const createInbox = () => new TestmailInbox({ prefix: env, suffix: 'otp.core' })
 const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 
 function checkIsString(value: string | unknown): asserts value is string {
@@ -281,7 +281,7 @@ describe('CommonNetworkMember [OTP]', () => {
   })
 
   describe('[with existing user]', () => {
-    let inbox: __dangerous.TestmailInbox
+    let inbox: TestmailInbox
 
     before(async () => {
       inbox = createInbox()

--- a/sdk/expo/CHANGELOG.md
+++ b/sdk/expo/CHANGELOG.md
@@ -1,3 +1,5 @@
+# release 5.0.1 (2021-06-21)
+* Removed TestmailInbox from `__dangerous`
 # release 5.0.0 (2021-06-16)
 * `getCredentials` now returns all credentials (even if there are more than 100 of them)
 * Performance optimization

--- a/sdk/expo/CHANGELOG.md
+++ b/sdk/expo/CHANGELOG.md
@@ -1,5 +1,5 @@
 # release 5.0.1 (2021-06-21)
-* Removed TestmailInbox from `__dangerous`
+* Removed TestmailInbox from `__dangerous` to fix unnecessary `crypto-random-string` import
 # release 5.0.0 (2021-06-16)
 * `getCredentials` now returns all credentials (even if there are more than 100 of them)
 * Performance optimization

--- a/sdk/expo/README.md
+++ b/sdk/expo/README.md
@@ -1,5 +1,11 @@
 # Affinity SDK for Expo
 
+> Please note that versions `>=4.2.6 <=5.0.0` might not work properly (see [this PR](https://github.com/affinityproject/affinidi-core-sdk/pull/105)).
+> 
+> For `v5`, please use versions `>=5.0.1`.
+> 
+> For `v4`, please use version `4.2.5` or, even better, update to `v5`.
+
 Expo SDK extends CORE SDK. Make sure to check the [CORE SDK documentation](https://www.npmjs.com/package/@affinidi/wallet-core-sdk).
 
 ## How to install

--- a/sdk/expo/package-lock.json
+++ b/sdk/expo/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@affinidi/wallet-expo-sdk",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@affinidi/wallet-expo-sdk",
-      "version": "5.0.0",
+      "version": "5.0.1",
       "license": "ISC",
       "dependencies": {
         "@affinidi/affinity-metrics-lib": "^0.0.25",

--- a/sdk/expo/package.json
+++ b/sdk/expo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@affinidi/wallet-expo-sdk",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "SDK monorepo for affinity DID solution for Expo",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/sdk/expo/test/integration/otp/index.test.ts
+++ b/sdk/expo/test/integration/otp/index.test.ts
@@ -4,6 +4,7 @@ import '../env'
 
 import { expect } from 'chai'
 import { __dangerous } from '@affinidi/wallet-core-sdk'
+import { TestmailInbox } from '@affinidi/wallet-core-sdk/dist/test-helpers'
 import { MessageParameters } from '@affinidi/wallet-core-sdk/dist/dto'
 import { SdkError } from '@affinidi/wallet-core-sdk/dist/shared'
 import { AffinityWallet } from '../../../src/AffinityWallet'
@@ -37,12 +38,12 @@ const messageParameters: MessageParameters = {
   subject: `Verification code`,
 }
 
-const waitForOtpCode = async (inbox: __dangerous.TestmailInbox): Promise<string> => {
+const waitForOtpCode = async (inbox: TestmailInbox): Promise<string> => {
   const { body } = await inbox.waitForNewEmail()
   return body.replace('Your verification code is: ', '')
 }
 
-const createInbox = () => new __dangerous.TestmailInbox({ prefix: env, suffix: 'otp.expo' })
+const createInbox = () => new TestmailInbox({ prefix: env, suffix: 'otp.expo' })
 const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 
 function checkIsString(value: string | unknown): asserts value is string {

--- a/sdk/react-native/CHANGELOG.md
+++ b/sdk/react-native/CHANGELOG.md
@@ -1,3 +1,5 @@
+# release 5.0.1 (2021-06-21)
+* Removed TestmailInbox from `__dangerous`
 # release 5.0.0 (2021-06-16)
 * `getCredentials` now returns all credentials (even if there are more than 100 of them)
 * Performance optimization

--- a/sdk/react-native/CHANGELOG.md
+++ b/sdk/react-native/CHANGELOG.md
@@ -1,5 +1,5 @@
 # release 5.0.1 (2021-06-21)
-* Removed TestmailInbox from `__dangerous`
+* Removed TestmailInbox from `__dangerous` to fix unnecessary `crypto-random-string` import
 # release 5.0.0 (2021-06-16)
 * `getCredentials` now returns all credentials (even if there are more than 100 of them)
 * Performance optimization

--- a/sdk/react-native/README.md
+++ b/sdk/react-native/README.md
@@ -1,5 +1,11 @@
 # Affinity SDK for React Native.
 
+> Please note that versions `>=4.2.6 <=5.0.0` might not work properly (see [this PR](https://github.com/affinityproject/affinidi-core-sdk/pull/105)).
+> 
+> For `v5`, please use versions `>=5.0.1`.
+> 
+> For `v4`, please use version `4.2.5` or, even better, update to `v5`.
+
 React Native SDK extends CORE SDK. Make sure to check the [CORE SDK documentation](https://github.com/affinityproject/affinidi-core-sdk/tree/master/sdk/core).
 
 ## How to install:

--- a/sdk/react-native/package-lock.json
+++ b/sdk/react-native/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@affinidi/wallet-react-native-sdk",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@affinidi/wallet-react-native-sdk",
-      "version": "5.0.0",
+      "version": "5.0.1",
       "license": "ISC",
       "dependencies": {
         "@affinidi/affinity-metrics-lib": "^0.0.25",

--- a/sdk/react-native/package.json
+++ b/sdk/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@affinidi/wallet-react-native-sdk",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "SDK for affinity DID solution for React Native",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/sdk/react-native/test/integration/otp/index.test.ts
+++ b/sdk/react-native/test/integration/otp/index.test.ts
@@ -4,6 +4,7 @@ import '../env'
 
 import { expect } from 'chai'
 import { __dangerous } from '@affinidi/wallet-core-sdk'
+import { TestmailInbox } from '@affinidi/wallet-core-sdk/dist/test-helpers'
 import { MessageParameters } from '@affinidi/wallet-core-sdk/dist/dto'
 import { AffinityWallet } from '../../../src/AffinityWallet'
 
@@ -37,12 +38,12 @@ const messageParameters: MessageParameters = {
   subject: `Verification code`,
 }
 
-const waitForOtpCode = async (inbox: __dangerous.TestmailInbox): Promise<string> => {
+const waitForOtpCode = async (inbox: TestmailInbox): Promise<string> => {
   const { body } = await inbox.waitForNewEmail()
   return body.replace('Your verification code is: ', '')
 }
 
-const createInbox = () => new __dangerous.TestmailInbox({ prefix: env, suffix: 'otp.react-native' })
+const createInbox = () => new TestmailInbox({ prefix: env, suffix: 'otp.react-native' })
 const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 
 function checkIsString(value: string | unknown): asserts value is string {


### PR DESCRIPTION
Fixes unnecessary import of "crypto-random-string" when it's not actually used (and fails because it's not available on every platform)

- Removed `TestmailInbox` from `__dangerous` exports
- Added `TestmailInbox` to `@affinidi/wallet-core-sdk/dist/test-helpers`
- Added `README` notice about faulty SDK versions
- Updated tests