### PR TITLE
[@affinidi/vc-common@1.4.1] [FTL-1639] Allow enabling compactProof for building & validating VCs

### DIFF
--- a/common-libs/vc-common/package-lock.json
+++ b/common-libs/vc-common/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@affinidi/vc-common",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@affinidi/vc-common",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "dependencies": {
         "did-resolver": "^3.1.0",
         "jsonld-signatures": "^7.0.0",
@@ -16,6 +16,7 @@
       "devDependencies": {
         "@affinidi/eslint-config": "1.0.1",
         "@affinidi/prettier-config": "1.0.1",
+        "@affinidi/tiny-lds-ecdsa-secp256k1-2019": "^1.1.0",
         "@mattrglobal/jsonld-signatures-bbs": "^0.10.0",
         "eslint-config-react-app": "6.0.0-next.77",
         "jsonld": "^4.0.1",
@@ -47,6 +48,23 @@
       "dev": true,
       "peerDependencies": {
         "prettier": "^2.0.5"
+      }
+    },
+    "node_modules/@affinidi/tiny-lds-ecdsa-secp256k1-2019": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@affinidi/tiny-lds-ecdsa-secp256k1-2019/-/tiny-lds-ecdsa-secp256k1-2019-1.1.0.tgz",
+      "integrity": "sha512-1HNzWW7awQh7d+OYD1C70BHh9O3D/jTkVtMcGuAUmthaRzWBX+Bz1tdkVPIobWxftYsn/mEBdu6sER9R3uwpXw==",
+      "dev": true,
+      "dependencies": {
+        "base64url": "^3.0.1",
+        "create-hash": "^1.2.0",
+        "jsonld": "^4.0.1",
+        "jsonld-signatures": "^7.0.0",
+        "tiny-secp256k1": "^1.1.6",
+        "tslib": "^2.0.1"
+      },
+      "peerDependencies": {
+        "elliptic": "^6.5.4"
       }
     },
     "node_modules/@affinityproject/prettier-config": {
@@ -3223,10 +3241,15 @@
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
       "dev": true,
-      "optional": true,
       "dependencies": {
         "file-uri-to-path": "1.0.0"
       }
+    },
+    "node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+      "dev": true
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -3279,6 +3302,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/brorand": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
+      "dev": true
     },
     "node_modules/browser-process-hrtime": {
       "version": "1.0.0",
@@ -3502,6 +3531,16 @@
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
       "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
       "dev": true
+    },
+    "node_modules/cipher-base": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/class-utils": {
       "version": "0.3.6",
@@ -4009,6 +4048,33 @@
         "node": ">=8"
       }
     },
+    "node_modules/create-hash": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+      "dev": true,
+      "dependencies": {
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "md5.js": "^1.3.4",
+        "ripemd160": "^2.0.1",
+        "sha.js": "^2.4.0"
+      }
+    },
+    "node_modules/create-hmac": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+      "dev": true,
+      "dependencies": {
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -4291,6 +4357,21 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.748.tgz",
       "integrity": "sha512-fmIKfYALVeEybk/L2ucdgt7jN3JsbGtg3K9pmF/MRWgkeADBI1VSAa5IzdG2gZwTxsnsrFtdMpOTSM5mrBRKVQ==",
       "dev": true
+    },
+    "node_modules/elliptic": {
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.11.9",
+        "brorand": "^1.1.0",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.1",
+        "inherits": "^2.0.4",
+        "minimalistic-assert": "^1.0.1",
+        "minimalistic-crypto-utils": "^1.0.1"
+      }
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -5413,8 +5494,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "node_modules/fill-range": {
       "version": "4.0.0",
@@ -6104,6 +6184,41 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/hash-base": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
+      "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.6.0",
+        "safe-buffer": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/hash.js": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      }
+    },
+    "node_modules/hmac-drbg": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+      "dev": true,
+      "dependencies": {
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
       }
     },
     "node_modules/hosted-git-info": {
@@ -8216,6 +8331,17 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/md5.js": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+      "dev": true,
+      "dependencies": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -8273,6 +8399,18 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "dev": true
+    },
+    "node_modules/minimalistic-crypto-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
+      "dev": true
     },
     "node_modules/minimatch": {
       "version": "3.0.4",
@@ -8363,8 +8501,7 @@
       "version": "2.14.2",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
       "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "node_modules/nanomatch": {
       "version": "1.2.13",
@@ -9627,6 +9764,20 @@
         "node": ">=4"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/readdir-scoped-modules": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.1.0.tgz",
@@ -10016,6 +10167,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/ripemd160": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+      "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+      "dev": true,
+      "dependencies": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
       }
     },
     "node_modules/rollup": {
@@ -10471,6 +10632,19 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+    },
+    "node_modules/sha.js": {
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      },
+      "bin": {
+        "sha.js": "bin.js"
+      }
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -11094,6 +11268,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/string-length": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
@@ -11514,6 +11697,23 @@
       "dependencies": {
         "globalyzer": "0.1.0",
         "globrex": "^0.1.2"
+      }
+    },
+    "node_modules/tiny-secp256k1": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/tiny-secp256k1/-/tiny-secp256k1-1.1.6.tgz",
+      "integrity": "sha512-FmqJZGduTyvsr2cF3375fqGHUovSwDi/QytexX1Se4BPuPZpTE5Ftp5fg+EFSuEf3lhZqgCRjEG3ydUQ/aNiwA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "bindings": "^1.3.0",
+        "bn.js": "^4.11.8",
+        "create-hmac": "^1.1.7",
+        "elliptic": "^6.4.0",
+        "nan": "^2.13.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/tiny-warning": {
@@ -12607,8 +12807,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "node_modules/util-extend": {
       "version": "1.0.3",
@@ -13174,6 +13373,20 @@
       "integrity": "sha512-gfyv27MdiqUFyCTBWY3SWJAbYm2aclg+7uqlUfVYoXMKwGpb/YkWwfqAgIzq6F3nLL4DjJIG1eln2XL/BDaIdA==",
       "dev": true,
       "requires": {}
+    },
+    "@affinidi/tiny-lds-ecdsa-secp256k1-2019": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@affinidi/tiny-lds-ecdsa-secp256k1-2019/-/tiny-lds-ecdsa-secp256k1-2019-1.1.0.tgz",
+      "integrity": "sha512-1HNzWW7awQh7d+OYD1C70BHh9O3D/jTkVtMcGuAUmthaRzWBX+Bz1tdkVPIobWxftYsn/mEBdu6sER9R3uwpXw==",
+      "dev": true,
+      "requires": {
+        "base64url": "^3.0.1",
+        "create-hash": "^1.2.0",
+        "jsonld": "^4.0.1",
+        "jsonld-signatures": "^7.0.0",
+        "tiny-secp256k1": "^1.1.6",
+        "tslib": "^2.0.1"
+      }
     },
     "@affinityproject/prettier-config": {
       "version": "1.0.1",
@@ -15758,10 +15971,15 @@
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
       "dev": true,
-      "optional": true,
       "requires": {
         "file-uri-to-path": "1.0.0"
       }
+    },
+    "bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+      "dev": true
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -15807,6 +16025,12 @@
           "dev": true
         }
       }
+    },
+    "brorand": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
+      "dev": true
     },
     "browser-process-hrtime": {
       "version": "1.0.0",
@@ -15991,6 +16215,16 @@
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
       "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
       "dev": true
+    },
+    "cipher-base": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
     },
     "class-utils": {
       "version": "0.3.6",
@@ -16402,6 +16636,33 @@
         }
       }
     },
+    "create-hash": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+      "dev": true,
+      "requires": {
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "md5.js": "^1.3.4",
+        "ripemd160": "^2.0.1",
+        "sha.js": "^2.4.0"
+      }
+    },
+    "create-hmac": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+      "dev": true,
+      "requires": {
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      }
+    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -16630,6 +16891,21 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.748.tgz",
       "integrity": "sha512-fmIKfYALVeEybk/L2ucdgt7jN3JsbGtg3K9pmF/MRWgkeADBI1VSAa5IzdG2gZwTxsnsrFtdMpOTSM5mrBRKVQ==",
       "dev": true
+    },
+    "elliptic": {
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+      "dev": true,
+      "requires": {
+        "bn.js": "^4.11.9",
+        "brorand": "^1.1.0",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.1",
+        "inherits": "^2.0.4",
+        "minimalistic-assert": "^1.0.1",
+        "minimalistic-crypto-utils": "^1.0.1"
+      }
     },
     "emoji-regex": {
       "version": "9.2.2",
@@ -17498,8 +17774,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "fill-range": {
       "version": "4.0.0",
@@ -18028,6 +18303,38 @@
             "is-buffer": "^1.1.5"
           }
         }
+      }
+    },
+    "hash-base": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
+      "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.6.0",
+        "safe-buffer": "^5.2.0"
+      }
+    },
+    "hash.js": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      }
+    },
+    "hmac-drbg": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+      "dev": true,
+      "requires": {
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
       }
     },
     "hosted-git-info": {
@@ -19710,6 +20017,17 @@
         "object-visit": "^1.0.0"
       }
     },
+    "md5.js": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+      "dev": true,
+      "requires": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
     "merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -19754,6 +20072,18 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true
+    },
+    "minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "dev": true
+    },
+    "minimalistic-crypto-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
       "dev": true
     },
     "minimatch": {
@@ -19833,8 +20163,7 @@
       "version": "2.14.2",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
       "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -20839,6 +21168,17 @@
         "read-pkg": "^3.0.0"
       }
     },
+    "readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      }
+    },
     "readdir-scoped-modules": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.1.0.tgz",
@@ -21138,6 +21478,16 @@
       "dev": true,
       "requires": {
         "glob": "^7.1.3"
+      }
+    },
+    "ripemd160": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+      "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+      "dev": true,
+      "requires": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
       }
     },
     "rollup": {
@@ -21494,6 +21844,16 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+    },
+    "sha.js": {
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
     },
     "shebang-command": {
       "version": "2.0.0",
@@ -22010,6 +22370,15 @@
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
       "dev": true
     },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "string-length": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
@@ -22345,6 +22714,19 @@
       "requires": {
         "globalyzer": "0.1.0",
         "globrex": "^0.1.2"
+      }
+    },
+    "tiny-secp256k1": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/tiny-secp256k1/-/tiny-secp256k1-1.1.6.tgz",
+      "integrity": "sha512-FmqJZGduTyvsr2cF3375fqGHUovSwDi/QytexX1Se4BPuPZpTE5Ftp5fg+EFSuEf3lhZqgCRjEG3ydUQ/aNiwA==",
+      "dev": true,
+      "requires": {
+        "bindings": "^1.3.0",
+        "bn.js": "^4.11.8",
+        "create-hmac": "^1.1.7",
+        "elliptic": "^6.4.0",
+        "nan": "^2.13.2"
       }
     },
     "tiny-warning": {
@@ -23165,8 +23547,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "util-extend": {
       "version": "1.0.3",

--- a/common-libs/vc-common/package.json
+++ b/common-libs/vc-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@affinidi/vc-common",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "main": "dist/index.js",
   "module": "dist/vc-common.esm.js",
   "typings": "dist/index.d.ts",

--- a/common-libs/vc-common/src/issuer/vcBuild/v1.ts
+++ b/common-libs/vc-common/src/issuer/vcBuild/v1.ts
@@ -79,6 +79,7 @@ type BuildVCV1 = <S extends VCV1SubjectBaseMA>(opts: {
   getSignSuite: GetSignSuiteFn
   documentLoader: DocumentLoader
   getProofPurposeOptions?: GetAssertionProofPurposeOptionsFn
+  compactProof?: boolean
 }) => Promise<VCV1<S>>
 
 export const buildVCV1: BuildVCV1 = async ({
@@ -87,6 +88,7 @@ export const buildVCV1: BuildVCV1 = async ({
   getSignSuite,
   documentLoader,
   getProofPurposeOptions,
+  compactProof = false,
 }) => {
   validateId(unsigned.id, true)
 
@@ -112,7 +114,7 @@ export const buildVCV1: BuildVCV1 = async ({
               })
             : {},
         ),
-        compactProof: false,
+        compactProof,
       },
     )
 

--- a/common-libs/vc-common/src/verifier/v1/bbs.test.ts
+++ b/common-libs/vc-common/src/verifier/v1/bbs.test.ts
@@ -101,6 +101,7 @@ const getVerifySuite: GetVerifySuiteFn = async ({ controller, verificationMethod
 
 const createVC = async (): Promise<VCV1> => {
   return buildVCV1({
+    compactProof: true,
     unsigned: buildVCV1Unsigned({
       skeleton: buildVCV1Skeleton({
         id: 'claimId:63b5d11c0d1b5566',
@@ -115,73 +116,76 @@ const createVC = async (): Promise<VCV1> => {
           id: holderDid,
         },
         type: 'NameCredentialPersonV1',
-        context: {
-          NameCredentialPersonV1: {
-            '@id': 'https://schema.affinity-project.org/NameCredentialPersonV1',
-            '@context': { '@version': 1.1, '@protected': true },
+        context: [
+          'https://w3id.org/security/bbs/v1',
+          {
+            NameCredentialPersonV1: {
+              '@id': 'https://schema.affinity-project.org/NameCredentialPersonV1',
+              '@context': { '@version': 1.1, '@protected': true },
+            },
+            data: {
+              '@id': 'https://schema.affinity-project.org/data',
+              '@context': [
+                null,
+                {
+                  '@version': 1.1,
+                  '@protected': true,
+                  '@vocab': 'https://schema.org/',
+                  NamePerson: {
+                    '@id': 'https://schema.affinity-project.org/NamePerson',
+                    '@context': {
+                      '@version': 1.1,
+                      '@protected': true,
+                      '@vocab': 'https://schema.org/',
+                      name: 'https://schema.org/name',
+                      givenName: 'https://schema.org/givenName',
+                      fullName: 'https://schema.org/fullName',
+                    },
+                  },
+                  PersonE: {
+                    '@id': 'https://schema.affinity-project.org/PersonE',
+                    '@context': { '@version': 1.1, '@protected': true, '@vocab': 'https://schema.org/' },
+                  },
+                  OrganizationE: {
+                    '@id': 'https://schema.affinity-project.org/OrganizationE',
+                    '@context': {
+                      '@version': 1.1,
+                      '@protected': true,
+                      '@vocab': 'https://schema.org/',
+                      hasCredential: 'https://schema.org/hasCredential',
+                      industry: 'https://schema.affinity-project.org/industry',
+                      identifiers: 'https://schema.affinity-project.org/identifiers',
+                    },
+                  },
+                  Credential: {
+                    '@id': 'https://schema.affinity-project.org/Credential',
+                    '@context': {
+                      '@version': 1.1,
+                      '@protected': true,
+                      '@vocab': 'https://schema.org/',
+                      dateRevoked: 'https://schema.affinity-project.org/dateRevoked',
+                      recognizedBy: 'https://schema.affinity-project.org/recognizedBy',
+                    },
+                  },
+                  OrganizationalCredential: {
+                    '@id': 'https://schema.affinity-project.org/OrganizationalCredential',
+                    '@context': {
+                      '@version': 1.1,
+                      '@protected': true,
+                      '@vocab': 'https://schema.org/',
+                      credentialCategory: 'https://schema.affinity-project.org/credentialCategory',
+                      organizationType: 'https://schema.affinity-project.org/organizationType',
+                      goodStanding: 'https://schema.affinity-project.org/goodStanding',
+                      active: 'https://schema.affinity-project.org/active',
+                      primaryJurisdiction: 'https://schema.affinity-project.org/primaryJurisdiction',
+                      identifier: 'https://schema.org/identifier',
+                    },
+                  },
+                },
+              ],
+            },
           },
-          data: {
-            '@id': 'https://schema.affinity-project.org/data',
-            '@context': [
-              null,
-              {
-                '@version': 1.1,
-                '@protected': true,
-                '@vocab': 'https://schema.org/',
-                NamePerson: {
-                  '@id': 'https://schema.affinity-project.org/NamePerson',
-                  '@context': {
-                    '@version': 1.1,
-                    '@protected': true,
-                    '@vocab': 'https://schema.org/',
-                    name: 'https://schema.org/name',
-                    givenName: 'https://schema.org/givenName',
-                    fullName: 'https://schema.org/fullName',
-                  },
-                },
-                PersonE: {
-                  '@id': 'https://schema.affinity-project.org/PersonE',
-                  '@context': { '@version': 1.1, '@protected': true, '@vocab': 'https://schema.org/' },
-                },
-                OrganizationE: {
-                  '@id': 'https://schema.affinity-project.org/OrganizationE',
-                  '@context': {
-                    '@version': 1.1,
-                    '@protected': true,
-                    '@vocab': 'https://schema.org/',
-                    hasCredential: 'https://schema.org/hasCredential',
-                    industry: 'https://schema.affinity-project.org/industry',
-                    identifiers: 'https://schema.affinity-project.org/identifiers',
-                  },
-                },
-                Credential: {
-                  '@id': 'https://schema.affinity-project.org/Credential',
-                  '@context': {
-                    '@version': 1.1,
-                    '@protected': true,
-                    '@vocab': 'https://schema.org/',
-                    dateRevoked: 'https://schema.affinity-project.org/dateRevoked',
-                    recognizedBy: 'https://schema.affinity-project.org/recognizedBy',
-                  },
-                },
-                OrganizationalCredential: {
-                  '@id': 'https://schema.affinity-project.org/OrganizationalCredential',
-                  '@context': {
-                    '@version': 1.1,
-                    '@protected': true,
-                    '@vocab': 'https://schema.org/',
-                    credentialCategory: 'https://schema.affinity-project.org/credentialCategory',
-                    organizationType: 'https://schema.affinity-project.org/organizationType',
-                    goodStanding: 'https://schema.affinity-project.org/goodStanding',
-                    active: 'https://schema.affinity-project.org/active',
-                    primaryJurisdiction: 'https://schema.affinity-project.org/primaryJurisdiction',
-                    identifier: 'https://schema.org/identifier',
-                  },
-                },
-              },
-            ],
-          },
-        } as any,
+        ] as any,
       }),
       issuanceDate: '2021-03-01T07:06:35.403Z',
       expirationDate: '2031-01-16T07:06:35.337Z',
@@ -224,6 +228,7 @@ describe('validateVCV1 [BBS+]', () => {
       documentLoader,
       getVerifySuite,
       getProofPurposeOptions,
+      compactProof: true,
     })(vc)
 
     if (res.kind === 'invalid') {
@@ -239,7 +244,7 @@ describe('validateVCV1 [BBS+]', () => {
 
       vc.proof.proofValue = ''
 
-      const res = await validateVCV1({ documentLoader, getVerifySuite })(vc)
+      const res = await validateVCV1({ documentLoader, getVerifySuite, compactProof: true })(vc)
 
       expectToBeInvalidWith(res, {
         kind: 'invalid_param',
@@ -253,7 +258,7 @@ describe('validateVCV1 [BBS+]', () => {
 
       delete vc.proof.proofValue
 
-      const res = await validateVCV1({ documentLoader, getVerifySuite })(vc)
+      const res = await validateVCV1({ documentLoader, getVerifySuite, compactProof: true })(vc)
 
       expectToBeInvalidWith(res, {
         kind: 'invalid_param',

--- a/common-libs/vc-common/src/verifier/v1/bbs.test.ts
+++ b/common-libs/vc-common/src/verifier/v1/bbs.test.ts
@@ -109,7 +109,7 @@ const createVC = async (): Promise<VCV1> => {
           data: {
             '@type': ['Person', 'PersonE', 'NamePerson'],
             givenName: 'Jon Smith',
-            familyName: 'Jon Family-Man Smith',
+            fullName: 'Jon Family-Man Smith',
           },
         },
         holder: {


### PR DESCRIPTION
- Added `compactProof` to `buildVCV1`
- Added `compactProof` to `validateVCV1`

Background:
Avoid `sec:` prefix for BBS+ proof type (`sec:BbsBlsSignature2020` and `sec:BbsBlsSignatureProof2020`).
Also `compactProof` has been deleted in the `jsonld-signatures` library since `8.0.0` (we use `7.0.0`)