### PR TITLE
FLT-1571 - hmac function for credential ID and types

### DIFF
--- a/sdk/browser/package-lock.json
+++ b/sdk/browser/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@affinidi/wallet-browser-sdk",
-  "version": "6.0.0-beta.1",
+  "version": "6.0.0-beta.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@affinidi/wallet-browser-sdk",
-      "version": "6.0.0-beta.1",
+      "version": "6.0.0-beta.2",
       "license": "ISC",
       "dependencies": {
         "@affinidi/affinity-metrics-lib": "^0.0.25",

--- a/sdk/browser/package.json
+++ b/sdk/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@affinidi/wallet-browser-sdk",
-  "version": "6.0.0-beta.1",
+  "version": "6.0.0-beta.2",
   "description": "SDK monorepo for affinity DID solution for browser",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -40,7 +40,7 @@
   "dependencies": {
     "@affinidi/affinity-metrics-lib": "^0.0.25",
     "@affinidi/common": "^2.0.0-beta.1",
-    "@affinidi/wallet-core-sdk": "^6.0.0-beta.1",
+    "@affinidi/wallet-core-sdk": "^6.0.0-beta.2",
     "eccrypto-js": "^5.0.0",
     "randombytes": "^2.1.0"
   },

--- a/sdk/browser/src/PlatformEncryptionTools.ts
+++ b/sdk/browser/src/PlatformEncryptionTools.ts
@@ -68,6 +68,15 @@ export class PlatformEncryptionTools {
 
     return serializedEncryptedDataString
   }
+
+  async signWithPrivateKey(privateKeyBuffer: Buffer, data: string) {
+    const dataBuffer = Buffer.from(data)
+
+    const signatureBuffer = await eccrypto.hmacSha256Sign(privateKeyBuffer, dataBuffer)
+    const signature = signatureBuffer.toString('hex')
+
+    return signature
+  }
 }
 
 const platformEncryptionTools = new PlatformEncryptionTools()

--- a/sdk/browser/src/PlatformEncryptionTools.ts
+++ b/sdk/browser/src/PlatformEncryptionTools.ts
@@ -69,7 +69,7 @@ export class PlatformEncryptionTools {
     return serializedEncryptedDataString
   }
 
-  async signWithPrivateKey(privateKeyBuffer: Buffer, data: string) {
+  async computePersonalHash(privateKeyBuffer: Buffer, data: string) {
     const dataBuffer = Buffer.from(data)
 
     const signatureBuffer = await eccrypto.hmacSha256Sign(privateKeyBuffer, dataBuffer)

--- a/sdk/browser/test/unit/PlatformEncryptionTools.test.ts
+++ b/sdk/browser/test/unit/PlatformEncryptionTools.test.ts
@@ -50,13 +50,23 @@ describe('PlatformEncryptionTools', () => {
     expect(response).to.eql(badEncryptedDataObject)
   })
 
-  it('#signWithPrivateKey', async () => {
+  it('#computePersonalHash', async () => {
     const keysService = new KeysService(encryptedSeed, password)
     const privateKey = keysService.getOwnPrivateKey()
 
-    const hash = await platformEncryptionTools.signWithPrivateKey(privateKey, signedCredential.id)
+    const hash = await platformEncryptionTools.computePersonalHash(privateKey, signedCredential.id)
     const result = await hmacSha256Verify(privateKey, Buffer.from(signedCredential.id), Buffer.from(hash, 'hex'))
 
     expect(result).to.true
+  })
+
+  it('#computePersonalHashWithSameArguments', async () => {
+    const keysService = new KeysService(encryptedSeed, password)
+    const privateKey = keysService.getOwnPrivateKey()
+
+    const firstHash = await platformEncryptionTools.computePersonalHash(privateKey, signedCredential.id)
+    const secondHash = await platformEncryptionTools.computePersonalHash(privateKey, signedCredential.id)
+
+    expect(firstHash).to.eql(secondHash)
   })
 })

--- a/sdk/browser/test/unit/PlatformEncryptionTools.test.ts
+++ b/sdk/browser/test/unit/PlatformEncryptionTools.test.ts
@@ -3,10 +3,12 @@
 import sinon from 'sinon'
 import { expect } from 'chai'
 import { KeysService } from '@affinidi/common'
+import { hmacSha256Verify } from 'eccrypto-js'
 
 import platformEncryptionTools, { PlatformEncryptionTools } from '../../src/PlatformEncryptionTools'
 import { generateTestDIDs } from '../factory/didFactory'
 import { stubDecryptSeed } from '../unit/stubs'
+const signedCredential = require('../factory/signedCredential')
 
 let seed: string
 let password: string
@@ -46,5 +48,15 @@ describe('PlatformEncryptionTools', () => {
     const response = await platformEncryptionTools.decryptByPrivateKey(privateKey, badEncryptedDataObjectString)
 
     expect(response).to.eql(badEncryptedDataObject)
+  })
+
+  it('#signWithPrivateKey', async () => {
+    const keysService = new KeysService(encryptedSeed, password)
+    const privateKey = keysService.getOwnPrivateKey()
+
+    const hash = await platformEncryptionTools.signWithPrivateKey(privateKey, signedCredential.id)
+    const result = await hmacSha256Verify(privateKey, Buffer.from(signedCredential.id), Buffer.from(hash, 'hex'))
+
+    expect(result).to.true
   })
 })

--- a/sdk/core/package-lock.json
+++ b/sdk/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@affinidi/wallet-core-sdk",
-  "version": "6.0.0-beta.1",
+  "version": "6.0.0-beta.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@affinidi/wallet-core-sdk",
-      "version": "6.0.0-beta.1",
+      "version": "6.0.0-beta.2",
       "license": "ISC",
       "dependencies": {
         "@affinidi/affinity-metrics-lib": "^0.0.25",

--- a/sdk/core/package.json
+++ b/sdk/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@affinidi/wallet-core-sdk",
-  "version": "6.0.0-beta.1",
+  "version": "6.0.0-beta.2",
   "description": "SDK core monorepo for affinity DID solution",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/sdk/core/src/shared/interfaces.ts
+++ b/sdk/core/src/shared/interfaces.ts
@@ -6,5 +6,5 @@ export interface IPlatformEncryptionTools {
   platformName: string
   decryptByPrivateKey(privateKeyBuffer: Buffer, encryptedDataString: string): Promise<any>
   encryptByPublicKey(publicKeyBuffer: Buffer, data: unknown): Promise<string>
-  signWithPrivateKey(privateKeyBuffer: Buffer, data: string): Promise<string>
+  computePersonalHash(privateKeyBuffer: Buffer, data: string): Promise<string>
 }

--- a/sdk/core/src/shared/interfaces.ts
+++ b/sdk/core/src/shared/interfaces.ts
@@ -6,4 +6,5 @@ export interface IPlatformEncryptionTools {
   platformName: string
   decryptByPrivateKey(privateKeyBuffer: Buffer, encryptedDataString: string): Promise<any>
   encryptByPublicKey(publicKeyBuffer: Buffer, data: unknown): Promise<string>
+  signWithPrivateKey(privateKeyBuffer: Buffer, data: string): Promise<string>
 }

--- a/sdk/core/test/helpers/testPlatformTools.ts
+++ b/sdk/core/test/helpers/testPlatformTools.ts
@@ -8,4 +8,7 @@ export const testPlatformTools: IPlatformEncryptionTools = {
   encryptByPublicKey: async () => {
     throw new Error('not implemented')
   },
+  signWithPrivateKey: async () => {
+    throw new Error('not implemented')
+  },
 }

--- a/sdk/core/test/helpers/testPlatformTools.ts
+++ b/sdk/core/test/helpers/testPlatformTools.ts
@@ -8,7 +8,7 @@ export const testPlatformTools: IPlatformEncryptionTools = {
   encryptByPublicKey: async () => {
     throw new Error('not implemented')
   },
-  signWithPrivateKey: async () => {
+  computePersonalHash: async () => {
     throw new Error('not implemented')
   },
 }

--- a/sdk/expo/package-lock.json
+++ b/sdk/expo/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@affinidi/wallet-expo-sdk",
-  "version": "6.0.0-beta.1",
+  "version": "6.0.0-beta.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@affinidi/wallet-expo-sdk",
-      "version": "6.0.0-beta.1",
+      "version": "6.0.0-beta.2",
       "license": "ISC",
       "dependencies": {
         "@affinidi/affinity-metrics-lib": "^0.0.25",

--- a/sdk/expo/package.json
+++ b/sdk/expo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@affinidi/wallet-expo-sdk",
-  "version": "6.0.0-beta.1",
+  "version": "6.0.0-beta.2",
   "description": "SDK monorepo for affinity DID solution for Expo",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -41,7 +41,7 @@
   "dependencies": {
     "@affinidi/affinity-metrics-lib": "^0.0.25",
     "@affinidi/common": "^2.0.0-beta.1",
-    "@affinidi/wallet-core-sdk": "^6.0.0-beta.1",
+    "@affinidi/wallet-core-sdk": "^6.0.0-beta.2",
     "assert": "^2.0.0",
     "buffer": "^5.6.0",
     "eccrypto-js": "^5.0.0",

--- a/sdk/expo/src/PlatformEncryptionTools.ts
+++ b/sdk/expo/src/PlatformEncryptionTools.ts
@@ -71,6 +71,15 @@ export class PlatformEncryptionTools {
 
     return serializedEncryptedDataString
   }
+
+  async signWithPrivateKey(privateKeyBuffer: Buffer, data: string) {
+    const dataBuffer = Buffer.from(data)
+
+    const signatureBuffer = await eccrypto.hmacSha256Sign(privateKeyBuffer, dataBuffer)
+    const signature = signatureBuffer.toString('hex')
+
+    return signature
+  }
 }
 
 const platformEncryptionTools = new PlatformEncryptionTools()

--- a/sdk/expo/src/PlatformEncryptionTools.ts
+++ b/sdk/expo/src/PlatformEncryptionTools.ts
@@ -72,7 +72,7 @@ export class PlatformEncryptionTools {
     return serializedEncryptedDataString
   }
 
-  async signWithPrivateKey(privateKeyBuffer: Buffer, data: string) {
+  async computePersonalHash(privateKeyBuffer: Buffer, data: string) {
     const dataBuffer = Buffer.from(data)
 
     const signatureBuffer = await eccrypto.hmacSha256Sign(privateKeyBuffer, dataBuffer)

--- a/sdk/expo/test/unit/PlatformEncryptionTools.test.ts
+++ b/sdk/expo/test/unit/PlatformEncryptionTools.test.ts
@@ -3,10 +3,12 @@
 import sinon from 'sinon'
 import { expect } from 'chai'
 import { KeysService } from '@affinidi/common'
+import { hmacSha256Verify } from 'eccrypto-js'
 
 import platformEncryptionTools, { PlatformEncryptionTools } from '../../src/PlatformEncryptionTools'
 import { generateTestDIDs } from '../factory/didFactory'
 import { stubDecryptSeed } from '../unit/stubs'
+const signedCredential = require('../factory/signedCredential')
 
 let seed: string
 let password: string
@@ -46,5 +48,15 @@ describe('PlatformEncryptionTools', () => {
     const response = await platformEncryptionTools.decryptByPrivateKey(privateKey, badEncryptedDataObjectString)
 
     expect(response).to.eql(badEncryptedDataObject)
+  })
+
+  it('#signWithPrivateKey', async () => {
+    const keysService = new KeysService(encryptedSeed, password)
+    const privateKey = keysService.getOwnPrivateKey()
+
+    const hash = await platformEncryptionTools.signWithPrivateKey(privateKey, signedCredential.id)
+    const result = await hmacSha256Verify(privateKey, Buffer.from(signedCredential.id), Buffer.from(hash, 'hex'))
+
+    expect(result).to.true
   })
 })

--- a/sdk/expo/test/unit/PlatformEncryptionTools.test.ts
+++ b/sdk/expo/test/unit/PlatformEncryptionTools.test.ts
@@ -50,11 +50,11 @@ describe('PlatformEncryptionTools', () => {
     expect(response).to.eql(badEncryptedDataObject)
   })
 
-  it('#signWithPrivateKey', async () => {
+  it('#computePersonalHash', async () => {
     const keysService = new KeysService(encryptedSeed, password)
     const privateKey = keysService.getOwnPrivateKey()
 
-    const hash = await platformEncryptionTools.signWithPrivateKey(privateKey, signedCredential.id)
+    const hash = await platformEncryptionTools.computePersonalHash(privateKey, signedCredential.id)
     const result = await hmacSha256Verify(privateKey, Buffer.from(signedCredential.id), Buffer.from(hash, 'hex'))
 
     expect(result).to.true

--- a/sdk/expo/test/unit/PlatformEncryptionTools.test.ts
+++ b/sdk/expo/test/unit/PlatformEncryptionTools.test.ts
@@ -59,4 +59,14 @@ describe('PlatformEncryptionTools', () => {
 
     expect(result).to.true
   })
+
+  it('#computePersonalHashWithSameArguments', async () => {
+    const keysService = new KeysService(encryptedSeed, password)
+    const privateKey = keysService.getOwnPrivateKey()
+
+    const firstHash = await platformEncryptionTools.computePersonalHash(privateKey, signedCredential.id)
+    const secondHash = await platformEncryptionTools.computePersonalHash(privateKey, signedCredential.id)
+
+    expect(firstHash).to.eql(secondHash)
+  })
 })

--- a/sdk/node/package-lock.json
+++ b/sdk/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@affinidi/wallet-node-sdk",
-  "version": "6.0.0-beta.1",
+  "version": "6.0.0-beta.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@affinidi/wallet-node-sdk",
-      "version": "6.0.0-beta.1",
+      "version": "6.0.0-beta.2",
       "license": "ISC",
       "dependencies": {
         "@affinidi/affinity-metrics-lib": "^0.0.25",

--- a/sdk/node/package.json
+++ b/sdk/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@affinidi/wallet-node-sdk",
-  "version": "6.0.0-beta.1",
+  "version": "6.0.0-beta.2",
   "description": "SDK monorepo for affinity DID solution for node",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -40,7 +40,7 @@
   "dependencies": {
     "@affinidi/affinity-metrics-lib": "^0.0.25",
     "@affinidi/common": "^2.0.0-beta.0",
-    "@affinidi/wallet-core-sdk": "^6.0.0-beta.1",
+    "@affinidi/wallet-core-sdk": "^6.0.0-beta.2",
     "eccrypto-js": "^5.0.0",
     "randombytes": "^2.1.0"
   },

--- a/sdk/node/src/PlatformEncryptionTools.ts
+++ b/sdk/node/src/PlatformEncryptionTools.ts
@@ -69,7 +69,7 @@ export class PlatformEncryptionTools {
     return serializedEncryptedDataString
   }
 
-  async signWithPrivateKey(privateKeyBuffer: Buffer, data: string) {
+  async computePersonalHash(privateKeyBuffer: Buffer, data: string) {
     const dataBuffer = Buffer.from(data)
 
     const signatureBuffer = await eccrypto.hmacSha256Sign(privateKeyBuffer, dataBuffer)

--- a/sdk/node/src/PlatformEncryptionTools.ts
+++ b/sdk/node/src/PlatformEncryptionTools.ts
@@ -68,6 +68,15 @@ export class PlatformEncryptionTools {
 
     return serializedEncryptedDataString
   }
+  
+  async signWithPrivateKey(privateKeyBuffer: Buffer, data: string) {
+    const dataBuffer = Buffer.from(data)
+
+    const signatureBuffer = await eccrypto.hmacSha256Sign(privateKeyBuffer, dataBuffer)
+    const signature = signatureBuffer.toString('hex')
+
+    return signature
+  }
 }
 
 const platformEncryptionTools = new PlatformEncryptionTools()

--- a/sdk/node/src/PlatformEncryptionTools.ts
+++ b/sdk/node/src/PlatformEncryptionTools.ts
@@ -68,7 +68,7 @@ export class PlatformEncryptionTools {
 
     return serializedEncryptedDataString
   }
-  
+
   async signWithPrivateKey(privateKeyBuffer: Buffer, data: string) {
     const dataBuffer = Buffer.from(data)
 

--- a/sdk/node/test/unit/PlatformEncryptionTools.test.ts
+++ b/sdk/node/test/unit/PlatformEncryptionTools.test.ts
@@ -3,10 +3,12 @@
 import sinon from 'sinon'
 import { expect } from 'chai'
 import { KeysService } from '@affinidi/common'
+import { hmacSha256Verify } from 'eccrypto-js'
 
 import platformEncryptionTools, { PlatformEncryptionTools } from '../../src/PlatformEncryptionTools'
 import { generateTestDIDs } from '../factory/didFactory'
 import { stubDecryptSeed } from '../unit/stubs'
+const signedCredential = require('../factory/signedCredential')
 
 let seed: string
 let password: string
@@ -46,5 +48,15 @@ describe('PlatformEncryptionTools', () => {
     const response = await platformEncryptionTools.decryptByPrivateKey(privateKey, badEncryptedDataObjectString)
 
     expect(response).to.eql(badEncryptedDataObject)
+  })
+
+  it('#signWithPrivateKey', async () => {
+    const keysService = new KeysService(encryptedSeed, password)
+    const privateKey = keysService.getOwnPrivateKey()
+
+    const hash = await platformEncryptionTools.signWithPrivateKey(privateKey, signedCredential.id)
+    const result = await hmacSha256Verify(privateKey, Buffer.from(signedCredential.id), Buffer.from(hash, 'hex'))
+
+    expect(result).to.true
   })
 })

--- a/sdk/node/test/unit/PlatformEncryptionTools.test.ts
+++ b/sdk/node/test/unit/PlatformEncryptionTools.test.ts
@@ -50,11 +50,11 @@ describe('PlatformEncryptionTools', () => {
     expect(response).to.eql(badEncryptedDataObject)
   })
 
-  it('#signWithPrivateKey', async () => {
+  it('#computePersonalHash', async () => {
     const keysService = new KeysService(encryptedSeed, password)
     const privateKey = keysService.getOwnPrivateKey()
 
-    const hash = await platformEncryptionTools.signWithPrivateKey(privateKey, signedCredential.id)
+    const hash = await platformEncryptionTools.computePersonalHash(privateKey, signedCredential.id)
     const result = await hmacSha256Verify(privateKey, Buffer.from(signedCredential.id), Buffer.from(hash, 'hex'))
 
     expect(result).to.true

--- a/sdk/node/test/unit/PlatformEncryptionTools.test.ts
+++ b/sdk/node/test/unit/PlatformEncryptionTools.test.ts
@@ -59,4 +59,14 @@ describe('PlatformEncryptionTools', () => {
 
     expect(result).to.true
   })
+
+  it('#computePersonalHashWithSameArguments', async () => {
+    const keysService = new KeysService(encryptedSeed, password)
+    const privateKey = keysService.getOwnPrivateKey()
+
+    const firstHash = await platformEncryptionTools.computePersonalHash(privateKey, signedCredential.id)
+    const secondHash = await platformEncryptionTools.computePersonalHash(privateKey, signedCredential.id)
+
+    expect(firstHash).to.eql(secondHash)
+  })
 })

--- a/sdk/react-native/package-lock.json
+++ b/sdk/react-native/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@affinidi/wallet-react-native-sdk",
-  "version": "6.0.0-beta.1",
+  "version": "6.0.0-beta.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@affinidi/wallet-react-native-sdk",
-      "version": "6.0.0-beta.1",
+      "version": "6.0.0-beta.2",
       "license": "ISC",
       "dependencies": {
         "@affinidi/affinity-metrics-lib": "^0.0.25",

--- a/sdk/react-native/package.json
+++ b/sdk/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@affinidi/wallet-react-native-sdk",
-  "version": "6.0.0-beta.1",
+  "version": "6.0.0-beta.2",
   "description": "SDK for affinity DID solution for React Native",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -34,7 +34,7 @@
   "dependencies": {
     "@affinidi/affinity-metrics-lib": "^0.0.25",
     "@affinidi/common": "^2.0.0-beta.1",
-    "@affinidi/wallet-core-sdk": "^6.0.0-beta.1",
+    "@affinidi/wallet-core-sdk": "^6.0.0-beta.2",
     "assert": "^2.0.0",
     "buffer": "^5.6.0",
     "eccrypto-js": "^5.0.0",

--- a/sdk/react-native/src/PlatformEncryptionTools.ts
+++ b/sdk/react-native/src/PlatformEncryptionTools.ts
@@ -64,7 +64,7 @@ export class PlatformEncryptionTools {
 
     return JSON.stringify(serializedEncryptedData)
   }
-  
+
   async signWithPrivateKey(privateKeyBuffer: Buffer, data: string) {
     const dataBuffer = Buffer.from(data)
 

--- a/sdk/react-native/src/PlatformEncryptionTools.ts
+++ b/sdk/react-native/src/PlatformEncryptionTools.ts
@@ -64,6 +64,15 @@ export class PlatformEncryptionTools {
 
     return JSON.stringify(serializedEncryptedData)
   }
+  
+  async signWithPrivateKey(privateKeyBuffer: Buffer, data: string) {
+    const dataBuffer = Buffer.from(data)
+
+    const signatureBuffer = await eccrypto.hmacSha256Sign(privateKeyBuffer, dataBuffer)
+    const signature = signatureBuffer.toString('hex')
+
+    return signature
+  }
 }
 
 const platformEncryptionTools = new PlatformEncryptionTools()

--- a/sdk/react-native/src/PlatformEncryptionTools.ts
+++ b/sdk/react-native/src/PlatformEncryptionTools.ts
@@ -65,7 +65,7 @@ export class PlatformEncryptionTools {
     return JSON.stringify(serializedEncryptedData)
   }
 
-  async signWithPrivateKey(privateKeyBuffer: Buffer, data: string) {
+  async computePersonalHash(privateKeyBuffer: Buffer, data: string) {
     const dataBuffer = Buffer.from(data)
 
     const signatureBuffer = await eccrypto.hmacSha256Sign(privateKeyBuffer, dataBuffer)

--- a/sdk/react-native/test/unit/PlatformEncryptionTools.test.ts
+++ b/sdk/react-native/test/unit/PlatformEncryptionTools.test.ts
@@ -50,11 +50,11 @@ describe('PlatformEncryptionTools', () => {
     expect(response).to.eql(badEncryptedDataObject)
   })
 
-  it('#signWithPrivateKey', async () => {
+  it('#computePersonalHash', async () => {
     const keysService = new KeysService(encryptedSeed, password)
     const privateKey = keysService.getOwnPrivateKey()
 
-    const hash = await platformEncryptionTools.signWithPrivateKey(privateKey, signedCredential.id)
+    const hash = await platformEncryptionTools.computePersonalHash(privateKey, signedCredential.id)
     const result = await hmacSha256Verify(privateKey, Buffer.from(signedCredential.id), Buffer.from(hash, 'hex'))
 
     expect(result).to.true

--- a/sdk/react-native/test/unit/PlatformEncryptionTools.test.ts
+++ b/sdk/react-native/test/unit/PlatformEncryptionTools.test.ts
@@ -59,4 +59,14 @@ describe('PlatformEncryptionTools', () => {
 
     expect(result).to.true
   })
+
+  it('#computePersonalHashWithSameArguments', async () => {
+    const keysService = new KeysService(encryptedSeed, password)
+    const privateKey = keysService.getOwnPrivateKey()
+
+    const firstHash = await platformEncryptionTools.computePersonalHash(privateKey, signedCredential.id)
+    const secondHash = await platformEncryptionTools.computePersonalHash(privateKey, signedCredential.id)
+
+    expect(firstHash).to.eql(secondHash)
+  })
 })

--- a/sdk/react-native/test/unit/PlatformEncryptionTools.test.ts
+++ b/sdk/react-native/test/unit/PlatformEncryptionTools.test.ts
@@ -3,10 +3,12 @@
 import sinon from 'sinon'
 import { expect } from 'chai'
 import { KeysService } from '@affinidi/common'
+import { hmacSha256Verify } from 'eccrypto-js'
 
 import platformEncryptionTools, { PlatformEncryptionTools } from '../../src/PlatformEncryptionTools'
 import { generateTestDIDs } from '../factory/didFactory'
 import { stubDecryptSeed } from '../unit/stubs'
+const signedCredential = require('../factory/signedCredential')
 
 let seed: string
 let password: string
@@ -46,5 +48,15 @@ describe('PlatformEncryptionTools', () => {
     const response = await platformEncryptionTools.decryptByPrivateKey(privateKeyBuffer, badEncryptedDataObjectString)
 
     expect(response).to.eql(badEncryptedDataObject)
+  })
+
+  it('#signWithPrivateKey', async () => {
+    const keysService = new KeysService(encryptedSeed, password)
+    const privateKey = keysService.getOwnPrivateKey()
+
+    const hash = await platformEncryptionTools.signWithPrivateKey(privateKey, signedCredential.id)
+    const result = await hmacSha256Verify(privateKey, Buffer.from(signedCredential.id), Buffer.from(hash, 'hex'))
+
+    expect(result).to.true
   })
 })


### PR DESCRIPTION
Fixes [FLT-1571](https://replika.atlassian.net/browse/FTL-1571) 

Added `signWithPrivateKey` method to `IPlatformEncryptionTools` and added for each implementation.
Added unit tests at each platform.
Upgraded version of `core`, `browser`, `node`, `expo` and `react-native` to `6.0.0-beta.2` version.