### PR TITLE
[FTL-1836] Support for 'ecdsa' key type in seed generation

### DIFF
--- a/common-libs/common/CHANGELOG.md
+++ b/common-libs/common/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 2.0.0-beta.9 (2021-09-15)
+* Support for ecdsa keys in seed generation
 # 2.0.0-beta.8 (2021-09-09)
 * DIDs are now resolved using `RegistryApiService` from `@affinidi/internal-api-clients`
 * Resolved DIDs are cached

--- a/common-libs/common/package-lock.json
+++ b/common-libs/common/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@affinidi/common",
-  "version": "2.0.0-beta.8",
+  "version": "2.0.0-beta.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@affinidi/common",
-      "version": "2.0.0-beta.8",
+      "version": "2.0.0-beta.9",
       "license": "ISC",
       "dependencies": {
         "@affinidi/affinity-metrics-lib": "^0.0.25",

--- a/common-libs/common/package.json
+++ b/common-libs/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@affinidi/common",
-  "version": "2.0.0-beta.8",
+  "version": "2.0.0-beta.9",
   "description": "Common utilities and types for Affinidi SDKs",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/common-libs/common/tsconfig.json
+++ b/common-libs/common/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "commonjs",
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "target": "ES2016",
+    "target": "ES2019",
     "noImplicitAny": true,
     "moduleResolution": "node",
     "sourceMap": true,

--- a/sdk/browser/package-lock.json
+++ b/sdk/browser/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@affinidi/wallet-browser-sdk",
-  "version": "6.0.0-beta.11",
+  "version": "6.0.0-beta.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@affinidi/wallet-browser-sdk",
-      "version": "6.0.0-beta.11",
+      "version": "6.0.0-beta.12",
       "license": "ISC",
       "dependencies": {
         "eccrypto-js": "^5.0.0",

--- a/sdk/browser/package.json
+++ b/sdk/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@affinidi/wallet-browser-sdk",
-  "version": "6.0.0-beta.11",
+  "version": "6.0.0-beta.12",
   "description": "SDK monorepo for affinity DID solution for browser",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -37,7 +37,7 @@
   ],
   "license": "ISC",
   "dependencies": {
-    "@affinidi/wallet-core-sdk": "^6.0.0-beta.11",
+    "@affinidi/wallet-core-sdk": "^6.0.0-beta.12",
     "eccrypto-js": "^5.0.0",
     "randombytes": "^2.1.0"
   },

--- a/sdk/core/CHANGELOG.md
+++ b/sdk/core/CHANGELOG.md
@@ -1,3 +1,5 @@
+# release 6.0.0-beta.12 (2021-09-15)
+* Updated internal dependencies
 # release 6.0.0-beta.11 (2021-09-09)
 * DIDs are now resolved using `Affinity` from `@affinidi/common`, which caches the resolved results.
 # release 6.0.0-beta.9 (2021-08-30)

--- a/sdk/core/package-lock.json
+++ b/sdk/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@affinidi/wallet-core-sdk",
-  "version": "6.0.0-beta.11",
+  "version": "6.0.0-beta.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@affinidi/wallet-core-sdk",
-      "version": "6.0.0-beta.11",
+      "version": "6.0.0-beta.12",
       "license": "ISC",
       "dependencies": {
         "@affinidi/affinity-metrics-lib": "^0.0.25",

--- a/sdk/core/package.json
+++ b/sdk/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@affinidi/wallet-core-sdk",
-  "version": "6.0.0-beta.11",
+  "version": "6.0.0-beta.12",
   "description": "SDK core monorepo for affinity DID solution",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -42,7 +42,7 @@
   "homepage": "https://github.com/affinityproject/affinidi-core-sdk#readme",
   "dependencies": {
     "@affinidi/affinity-metrics-lib": "^0.0.25",
-    "@affinidi/common": "^2.0.0-beta.8",
+    "@affinidi/common": "^2.0.0-beta.9",
     "@affinidi/internal-api-clients": "^1.0.0-beta.11",
     "@affinidi/issuer-email-ses-client": "^0.1.1",
     "@affinidi/issuer-phone-twilio-client": "^0.1.1",

--- a/sdk/expo/package-lock.json
+++ b/sdk/expo/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@affinidi/wallet-expo-sdk",
-  "version": "6.0.0-beta.11",
+  "version": "6.0.0-beta.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@affinidi/wallet-expo-sdk",
-      "version": "6.0.0-beta.11",
+      "version": "6.0.0-beta.12",
       "license": "ISC",
       "dependencies": {
         "assert": "^2.0.0",

--- a/sdk/expo/package.json
+++ b/sdk/expo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@affinidi/wallet-expo-sdk",
-  "version": "6.0.0-beta.11",
+  "version": "6.0.0-beta.12",
   "description": "SDK monorepo for affinity DID solution for Expo",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -38,7 +38,7 @@
   ],
   "license": "ISC",
   "dependencies": {
-    "@affinidi/wallet-core-sdk": "^6.0.0-beta.10",
+    "@affinidi/wallet-core-sdk": "^6.0.0-beta.12",
     "assert": "^2.0.0",
     "buffer": "^5.6.0",
     "eccrypto-js": "^5.0.0",

--- a/sdk/node/package-lock.json
+++ b/sdk/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@affinidi/wallet-node-sdk",
-  "version": "6.0.0-beta.11",
+  "version": "6.0.0-beta.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@affinidi/wallet-node-sdk",
-      "version": "6.0.0-beta.11",
+      "version": "6.0.0-beta.12",
       "license": "ISC",
       "dependencies": {
         "@mattrglobal/bbs-signatures": "^0.6.0",

--- a/sdk/node/package.json
+++ b/sdk/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@affinidi/wallet-node-sdk",
-  "version": "6.0.0-beta.11",
+  "version": "6.0.0-beta.12",
   "description": "SDK monorepo for affinity DID solution for node",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -37,7 +37,7 @@
   ],
   "license": "ISC",
   "dependencies": {
-    "@affinidi/wallet-core-sdk": "^6.0.0-beta.11",
+    "@affinidi/wallet-core-sdk": "^6.0.0-beta.12",
     "@mattrglobal/bbs-signatures": "^0.6.0",
     "@mattrglobal/jsonld-signatures-bbs": "^0.10.0",
     "@mattrglobal/node-bbs-signatures": "^0.11.0",

--- a/sdk/react-native/package-lock.json
+++ b/sdk/react-native/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@affinidi/wallet-react-native-sdk",
-  "version": "6.0.0-beta.10",
+  "version": "6.0.0-beta.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@affinidi/wallet-react-native-sdk",
-      "version": "6.0.0-beta.10",
+      "version": "6.0.0-beta.12",
       "license": "ISC",
       "dependencies": {
         "assert": "^2.0.0",

--- a/sdk/react-native/package.json
+++ b/sdk/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@affinidi/wallet-react-native-sdk",
-  "version": "6.0.0-beta.10",
+  "version": "6.0.0-beta.12",
   "description": "SDK for affinity DID solution for React Native",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -31,7 +31,7 @@
   "author": "Roman Brazhnyk <roman@affinity-project.org>",
   "license": "ISC",
   "dependencies": {
-    "@affinidi/wallet-core-sdk": "^6.0.0-beta.10",
+    "@affinidi/wallet-core-sdk": "^6.0.0-beta.12",
     "assert": "^2.0.0",
     "buffer": "^5.6.0",
     "eccrypto-js": "^5.0.0",


### PR DESCRIPTION
This PR is equivalent to (a half of) https://gitlab.com/affinidi/foundational/cloud-wallet-api/-/merge_requests/120 , and should be in `affinidi-core-sdk` along with the keys and seed generation as a part of cloud-wallet-api upgrade to SDK v6.