### PR TITLE
FTL-2199 fix aud not set correctly when creating response tokens

### DIFF
--- a/common-libs/common/package-lock.json
+++ b/common-libs/common/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@affinidi/common",
-  "version": "2.0.0-beta.12",
+  "version": "2.0.0-beta.17",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@affinidi/common",
-      "version": "2.0.0-beta.12",
+      "version": "2.0.0-beta.17",
       "license": "ISC",
       "dependencies": {
         "@affinidi/affinity-metrics-lib": "^0.0.25",

--- a/common-libs/common/package.json
+++ b/common-libs/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@affinidi/common",
-  "version": "2.0.0-beta.12",
+  "version": "2.0.0-beta.17",
   "description": "Common utilities and types for Affinidi SDKs",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/common-libs/common/src/services/JwtService.ts
+++ b/common-libs/common/src/services/JwtService.ts
@@ -56,8 +56,7 @@ export default class JwtService {
     }
 
     if (receivedToken) {
-      const keyId = receivedToken.payload.iss
-      const did = keyId.substring(0, keyId.indexOf('#'))
+      const did = DidDocumentService.keyIdToDid(receivedToken.payload.iss)
       jwt.payload.aud = did
       jwt.payload.jti = receivedToken.payload.jti
     } else {

--- a/common-libs/common/test/unit/services/JwtService.test.ts
+++ b/common-libs/common/test/unit/services/JwtService.test.ts
@@ -30,4 +30,40 @@ describe('JwtService', () => {
     expect(object).to.exist
     expect(object.payload).to.exist
   })
+
+  describe('#buildJWTInteractionToken', () => {
+    const interactionToken = {}
+    const typ = 'randomTyp'
+
+    it('should work without receivedToken', async () => {
+      const jwtObject = await JwtService.buildJWTInteractionToken(interactionToken, typ, null)
+
+      expect(jwtObject).to.exist
+      expect(jwtObject.payload).to.exist
+      expect(jwtObject.payload.interactionToken).to.eq(interactionToken)
+      expect(jwtObject.payload.typ).to.eq(typ)
+      expect(jwtObject.payload.jti).to.exist
+    })
+
+    it('should propagate the jti and issuer of received token', async () => {
+      const differentIssuers = [
+        { iss: 'did:test:received-token-issuer#primary', expectedAud: 'did:test:received-token-issuer' },
+        { iss: 'did:test:received-token-issuer', expectedAud: 'did:test:received-token-issuer' },
+      ]
+
+      for (const { iss, expectedAud } of differentIssuers) {
+        const jti = 'jti'
+        const receivedToken = { payload: { jti, iss } }
+
+        const jwtObject = await JwtService.buildJWTInteractionToken(interactionToken, typ, receivedToken)
+
+        expect(jwtObject).to.exist
+        expect(jwtObject.payload).to.exist
+        expect(jwtObject.payload.interactionToken).to.eq(interactionToken)
+        expect(jwtObject.payload.typ).to.eq(typ)
+        expect(jwtObject.payload.jti).to.eq(jti)
+        expect(jwtObject.payload.aud).to.eq(expectedAud)
+      }
+    })
+  })
 })

--- a/sdk/browser/package-lock.json
+++ b/sdk/browser/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@affinidi/wallet-browser-sdk",
-  "version": "6.0.0-beta.14",
+  "version": "6.0.0-beta.17",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@affinidi/wallet-browser-sdk",
-      "version": "6.0.0-beta.14",
+      "version": "6.0.0-beta.17",
       "license": "ISC",
       "dependencies": {
         "eccrypto-js": "^5.0.0",

--- a/sdk/browser/package.json
+++ b/sdk/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@affinidi/wallet-browser-sdk",
-  "version": "6.0.0-beta.14",
+  "version": "6.0.0-beta.17",
   "description": "SDK monorepo for affinity DID solution for browser",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -37,12 +37,12 @@
   ],
   "license": "ISC",
   "dependencies": {
-    "@affinidi/wallet-core-sdk": "^6.0.0-beta.15",
+    "@affinidi/wallet-core-sdk": "^6.0.0-beta.17",
     "eccrypto-js": "^5.0.0",
     "randombytes": "^2.1.0"
   },
   "devDependencies": {
-    "@affinidi/common": "^2.0.0-beta.7",
+    "@affinidi/common": "^2.0.0-beta.17",
     "@affinidi/eslint-config": "1.0.1",
     "@affinidi/prettier-config": "1.0.1",
     "@types/chai": "4.2.12",

--- a/sdk/core/package-lock.json
+++ b/sdk/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@affinidi/wallet-core-sdk",
-  "version": "6.0.0-beta.16",
+  "version": "6.0.0-beta.17",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@affinidi/wallet-core-sdk",
-      "version": "6.0.0-beta.16",
+      "version": "6.0.0-beta.17",
       "license": "ISC",
       "dependencies": {
         "@affinidi/affinity-metrics-lib": "^0.0.25",

--- a/sdk/core/package.json
+++ b/sdk/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@affinidi/wallet-core-sdk",
-  "version": "6.0.0-beta.16",
+  "version": "6.0.0-beta.17",
   "description": "SDK core monorepo for affinity DID solution",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -42,7 +42,7 @@
   "homepage": "https://github.com/affinityproject/affinidi-core-sdk#readme",
   "dependencies": {
     "@affinidi/affinity-metrics-lib": "^0.0.25",
-    "@affinidi/common": "^2.0.0-beta.9",
+    "@affinidi/common": "^2.0.0-beta.17",
     "@affinidi/internal-api-clients": "^1.0.0-beta.12",
     "@affinidi/issuer-email-ses-client": "^0.1.1",
     "@affinidi/issuer-phone-twilio-client": "^0.1.1",

--- a/sdk/expo/package-lock.json
+++ b/sdk/expo/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@affinidi/wallet-expo-sdk",
-  "version": "6.0.0-beta.14",
+  "version": "6.0.0-beta.17",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@affinidi/wallet-expo-sdk",
-      "version": "6.0.0-beta.14",
+      "version": "6.0.0-beta.17",
       "license": "ISC",
       "dependencies": {
         "assert": "^2.0.0",

--- a/sdk/expo/package.json
+++ b/sdk/expo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@affinidi/wallet-expo-sdk",
-  "version": "6.0.0-beta.14",
+  "version": "6.0.0-beta.17",
   "description": "SDK monorepo for affinity DID solution for Expo",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -38,7 +38,7 @@
   ],
   "license": "ISC",
   "dependencies": {
-    "@affinidi/wallet-core-sdk": "^6.0.0-beta.15",
+    "@affinidi/wallet-core-sdk": "^6.0.0-beta.17",
     "assert": "^2.0.0",
     "buffer": "^5.6.0",
     "eccrypto-js": "^5.0.0",
@@ -48,7 +48,7 @@
     "text-encoding": "^0.7.0"
   },
   "devDependencies": {
-    "@affinidi/common": "^2.0.0-beta.7",
+    "@affinidi/common": "^2.0.0-beta.17",
     "@affinidi/eslint-config": "1.0.1",
     "@affinidi/prettier-config": "1.0.1",
     "@types/chai": "4.2.12",

--- a/sdk/node/package-lock.json
+++ b/sdk/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@affinidi/wallet-node-sdk",
-  "version": "6.0.0-beta.14",
+  "version": "6.0.0-beta.17",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@affinidi/wallet-node-sdk",
-      "version": "6.0.0-beta.14",
+      "version": "6.0.0-beta.17",
       "license": "ISC",
       "dependencies": {
         "@mattrglobal/bbs-signatures": "^0.6.0",

--- a/sdk/node/package.json
+++ b/sdk/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@affinidi/wallet-node-sdk",
-  "version": "6.0.0-beta.14",
+  "version": "6.0.0-beta.17",
   "description": "SDK monorepo for affinity DID solution for node",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -37,7 +37,7 @@
   ],
   "license": "ISC",
   "dependencies": {
-    "@affinidi/wallet-core-sdk": "^6.0.0-beta.15",
+    "@affinidi/wallet-core-sdk": "^6.0.0-beta.17",
     "@mattrglobal/bbs-signatures": "^0.6.0",
     "@mattrglobal/jsonld-signatures-bbs": "^0.10.0",
     "@mattrglobal/node-bbs-signatures": "^0.11.0",
@@ -48,7 +48,7 @@
     "randombytes": "^2.1.0"
   },
   "devDependencies": {
-    "@affinidi/common": "^2.0.0-beta.7",
+    "@affinidi/common": "^2.0.0-beta.17",
     "@affinidi/eslint-config": "1.0.1",
     "@affinidi/prettier-config": "1.0.1",
     "@affinidi/vc-common": "^1.4.2",

--- a/sdk/react-native/package-lock.json
+++ b/sdk/react-native/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@affinidi/wallet-react-native-sdk",
-  "version": "6.0.0-beta.14",
+  "version": "6.0.0-beta.17",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@affinidi/wallet-react-native-sdk",
-      "version": "6.0.0-beta.14",
+      "version": "6.0.0-beta.17",
       "license": "ISC",
       "dependencies": {
         "assert": "^2.0.0",

--- a/sdk/react-native/package.json
+++ b/sdk/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@affinidi/wallet-react-native-sdk",
-  "version": "6.0.0-beta.14",
+  "version": "6.0.0-beta.17",
   "description": "SDK for affinity DID solution for React Native",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -31,7 +31,7 @@
   "author": "Roman Brazhnyk <roman@affinity-project.org>",
   "license": "ISC",
   "dependencies": {
-    "@affinidi/wallet-core-sdk": "^6.0.0-beta.15",
+    "@affinidi/wallet-core-sdk": "^6.0.0-beta.17",
     "assert": "^2.0.0",
     "buffer": "^5.6.0",
     "eccrypto-js": "^5.0.0",
@@ -44,7 +44,7 @@
     "vm-browserify": "^1.1.2"
   },
   "devDependencies": {
-    "@affinidi/common": "^2.0.0-beta.7",
+    "@affinidi/common": "^2.0.0-beta.17",
     "@affinidi/eslint-config": "1.0.1",
     "@affinidi/prettier-config": "1.0.1",
     "@types/chai": "4.2.12",


### PR DESCRIPTION
## Context
https://replika.atlassian.net/browse/FTL-2199

## Implementation
Used already imported `DidDocumentService` documents static method to parse did correctly.