### PR TITLE
fix: FTL-2256 fab uses register method returns wallet with resolvable did

### DIFF
--- a/sdk/core/src/services/registeringHandler.ts
+++ b/sdk/core/src/services/registeringHandler.ts
@@ -31,7 +31,6 @@ export const register = async (
     return { did: anchoredInBlockchainDid, encryptedSeed: anchoredEncryptedSeed, didDocumentKeyId }
   }
 
-  const did = didDocument.id
   const didDocumentKeyId = keyId
-  return { did, didDocumentKeyId, encryptedSeed }
+  return { did: didDocumentService.getMyDid(), didDocumentKeyId, encryptedSeed }
 }

--- a/sdk/core/test/integration/NetworkMember.test.ts
+++ b/sdk/core/test/integration/NetworkMember.test.ts
@@ -20,6 +20,7 @@ import { generateCredentials } from '../helpers/generateCredentials'
 import { SignedCredential } from '../../src/dto'
 import { testPlatformTools } from '../helpers/testPlatformTools'
 import { RegistryApiService } from '@affinidi/internal-api-clients'
+import { DidMethod, SdkOptions } from '../../dist'
 
 const {
   PASSWORD,
@@ -1106,7 +1107,7 @@ describe('CommonNetworkMember', () => {
 
     const resolvedDidDocument = await commonNetworkMember.resolveDid(commonNetworkMember.did)
 
-    expect(resolvedDidDocument.id).equal(commonNetworkMember.didDocumentKeyId.split('#')[0])
+    expect(commonNetworkMember.did.includes(resolvedDidDocument.id)).to.be.eql(true)
     expect(resolvedDidDocument.publicKey.length).to.be.gte(1)
   })
 
@@ -1121,7 +1122,7 @@ describe('CommonNetworkMember', () => {
 
     const resolvedDidDocument = await commonNetworkMember.resolveDid(commonNetworkMember.did)
 
-    expect(resolvedDidDocument.id).equal(commonNetworkMember.didDocumentKeyId.split('#')[0])
+    expect(commonNetworkMember.did.includes(resolvedDidDocument.id)).to.be.eql(true)
     expect(resolvedDidDocument.publicKey.length).to.be.gte(1)
   })
 
@@ -1136,7 +1137,46 @@ describe('CommonNetworkMember', () => {
 
     const resolvedDidDocument = await commonNetworkMember.resolveDid(commonNetworkMember.did)
 
-    expect(resolvedDidDocument.id).equal(commonNetworkMember.didDocumentKeyId.split('#')[0])
+    expect(commonNetworkMember.did.includes(resolvedDidDocument.id)).to.be.eql(true)
     expect(resolvedDidDocument.publicKey.length).to.be.gte(1)
+  })
+
+  it('#createWallet and #openWalletByEncryptedSeed should return the same did (elem)', async () => {
+    const customOptions: SdkOptions = { ...options, didMethod: 'elem' }
+    const cnmByCreateWallet = await AffinidiWallet.createWallet(customOptions, password)
+
+    const cnmByOpenWalletByEncryptedSeed = await AffinidiWallet.openWalletByEncryptedSeed(
+      customOptions,
+      cnmByCreateWallet.encryptedSeed,
+      password,
+    )
+
+    expect(cnmByCreateWallet.did).to.be.eql(cnmByOpenWalletByEncryptedSeed.did)
+  })
+
+  it('#createWallet and #openWalletByEncryptedSeed should return the same did (elem-anchored)', async () => {
+    const customOptions: SdkOptions = { ...options, didMethod: 'elem-anchored' }
+    const cnmByCreateWallet = await AffinidiWallet.createWallet(customOptions, password)
+
+    const cnmByOpenWalletByEncryptedSeed = await AffinidiWallet.openWalletByEncryptedSeed(
+      customOptions,
+      cnmByCreateWallet.encryptedSeed,
+      password,
+    )
+
+    expect(cnmByCreateWallet.did).to.be.eql(cnmByOpenWalletByEncryptedSeed.did)
+  })
+
+  it('#createWallet and #openWalletByEncryptedSeed should return the same did (jolo)', async () => {
+    const customOptions: SdkOptions = { ...options, didMethod: 'jolo' }
+    const cnmByCreateWallet = await AffinidiWallet.createWallet(customOptions, password)
+
+    const cnmByOpenWalletByEncryptedSeed = await AffinidiWallet.openWalletByEncryptedSeed(
+      customOptions,
+      cnmByCreateWallet.encryptedSeed,
+      password,
+    )
+
+    expect(cnmByCreateWallet.did).to.be.eql(cnmByOpenWalletByEncryptedSeed.did)
   })
 })

--- a/sdk/core/test/integration/NetworkMember.test.ts
+++ b/sdk/core/test/integration/NetworkMember.test.ts
@@ -17,10 +17,9 @@ import {
 } from '../helpers'
 import { credentialShareRequestTokenToFilterCredentials } from '../factory/credentialShareRequestToken'
 import { generateCredentials } from '../helpers/generateCredentials'
-import { SignedCredential } from '../../src/dto'
+import { SignedCredential, SdkOptions } from '../../src/dto'
 import { testPlatformTools } from '../helpers/testPlatformTools'
 import { RegistryApiService } from '@affinidi/internal-api-clients'
-import { DidMethod, SdkOptions } from '../../dist'
 
 const {
   PASSWORD,

--- a/sdk/core/test/integration/NetworkMember.test.ts
+++ b/sdk/core/test/integration/NetworkMember.test.ts
@@ -408,34 +408,34 @@ describe('CommonNetworkMember', () => {
   it('#register and #signUpWithExistsEntity (userName is arbitrary) and #fromLoginAndPassword', async () => {
     const { did, encryptedSeed } = await AffinidiWallet.register(password, options)
     const keyParams = { encryptedSeed, password }
-    const username = did
+    const username = did.split(';elem:')[0]
 
     const affinityWallet = await AffinidiWallet.signUpWithExistsEntity(keyParams, username, cognitoPassword, options)
     checkIsWallet(affinityWallet)
 
-    const walletShortDid = affinityWallet.did.split(';elem:')[0]
-    expect(walletShortDid).to.equal(did)
+    const walletDid = affinityWallet.did
+    expect(walletDid).to.equal(did)
 
     const affinityWalletAfterLogin = await AffinidiWallet.fromLoginAndPassword(username, cognitoPassword, options)
-    const walletAfterLoginShortDid = affinityWalletAfterLogin.did.split(';elem:')[0]
-    expect(walletAfterLoginShortDid).to.equal(did)
+    const walletAfterLoginDid = affinityWalletAfterLogin.did
+    expect(walletAfterLoginDid).to.equal(did)
   })
 
   it('#register and #signUpWithExistsEntity (userName is arbitrary with week password) and #fromLoginAndPassword', async () => {
     const userPassword = '092376'
     const { did, encryptedSeed } = await AffinidiWallet.register(password, options)
     const keyParams = { encryptedSeed, password }
-    const username = did
+    const username = did.split(';elem:')[0]
 
     const affinityWallet = await AffinidiWallet.signUpWithExistsEntity(keyParams, username, userPassword, options)
     checkIsWallet(affinityWallet)
 
-    const walletShortDid = affinityWallet.did.split(';elem:')[0]
-    expect(walletShortDid).to.equal(did)
+    const walletDid = affinityWallet.did
+    expect(walletDid).to.equal(did)
 
     const affinityWalletAfterLogin = await AffinidiWallet.fromLoginAndPassword(username, userPassword, options)
-    const walletAfterLoginShortDid = affinityWalletAfterLogin.did.split(';elem:')[0]
-    expect(walletAfterLoginShortDid).to.equal(did)
+    const walletAfterLoginDid = affinityWalletAfterLogin.did
+    expect(walletAfterLoginDid).to.equal(did)
   })
 
   it('#generateCredentialOfferRequestToken', async () => {
@@ -1093,5 +1093,50 @@ describe('CommonNetworkMember', () => {
   it('#deleteAllCredentials', async () => {
     const commonNetworkMember = new AffinidiWallet(password, encryptedSeedElem, options)
     await commonNetworkMember.deleteAllCredentials()
+  })
+
+  it('#createWallet should return wallet with resolvable did (elem)', async () => {
+    const commonNetworkMember = await AffinidiWallet.createWallet(
+      {
+        ...options,
+        didMethod: 'elem',
+      },
+      password,
+    )
+
+    const resolvedDidDocument = await commonNetworkMember.resolveDid(commonNetworkMember.did)
+
+    expect(resolvedDidDocument.id).equal(commonNetworkMember.didDocumentKeyId.split('#')[0])
+    expect(resolvedDidDocument.publicKey.length).to.be.gte(1)
+  })
+
+  it('#createWallet should return wallet with resolvable did (elem-anchored)', async () => {
+    const commonNetworkMember = await AffinidiWallet.createWallet(
+      {
+        ...options,
+        didMethod: 'elem-anchored',
+      },
+      password,
+    )
+
+    const resolvedDidDocument = await commonNetworkMember.resolveDid(commonNetworkMember.did)
+
+    expect(resolvedDidDocument.id).equal(commonNetworkMember.didDocumentKeyId.split('#')[0])
+    expect(resolvedDidDocument.publicKey.length).to.be.gte(1)
+  })
+
+  it('#createWallet should return wallet with resolvable did (jolo)', async () => {
+    const commonNetworkMember = await AffinidiWallet.createWallet(
+      {
+        ...options,
+        didMethod: 'jolo',
+      },
+      password,
+    )
+
+    const resolvedDidDocument = await commonNetworkMember.resolveDid(commonNetworkMember.did)
+
+    expect(resolvedDidDocument.id).equal(commonNetworkMember.didDocumentKeyId.split('#')[0])
+    expect(resolvedDidDocument.publicKey.length).to.be.gte(1)
   })
 })


### PR DESCRIPTION
All old implementation that create common network member returns it with resolvable did (e.g. for old elem with initial state), 
 but new implementation of factory method "createWallet" used method registry that could return not resolvable did (for old elem method - short version without initial state, which obviously can't be resolved)
This PR provides a fix and bunch of int tests 