### PR TITLE
Fixes #173

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,16 @@
-# Affinidi SDK Monorepo
+<h1 align="center">
+🦄 Affinidi Core SDK
+</h1>
+
+<h3 align="center">
+Build Self Sovereign Identity (SSI) applications using our JS/TS based platform SDKs
+</h3>
+
+<p align="center">
+    <a href="https://discord.com/invite/ffV5ctBMXr"><img src="https://img.shields.io/discord/806805256314028082?logo=discord?colorB=fedcba"/></a>
+    <img src="https://shields.io/badge/PRs-welcome-brightgreen"/>
+</p>
+<hr/>
 
 The open-source [Affinidi Library](https://github.com/affinityproject/affinidi-core-sdk) provides easy-to-use Typescript packages that enable developers to create and manage true certificate-enabled Digital Identities (DID) on the Affinidi Network.
 


### PR DESCRIPTION
Hey @launganik the following PR resolves the issue #173 

The chat widget shows disabled, because Affinidi Discord Server has disabled widgets. I have informed the community and partnerships to enable it.

<img width="912" alt="image" src="https://user-images.githubusercontent.com/53480076/140466137-f9a83df6-8388-486b-b9e1-64c85ab5459a.png">
