### PR TITLE
Improved React native integration setup readme

### DIFF
--- a/sdk/react-native/README.md
+++ b/sdk/react-native/README.md
@@ -25,7 +25,17 @@ You may need some polyfills as some of the dependencies assume running in a Node
 ```shell script
 npm install --save vm-browserify stream-browserify @react-native-community/netinfo \
   react-native-crypto react-native-randombytes react-native-get-random-values \
-  amazon-cognito-identity-js assert events
+  amazon-cognito-identity-js assert events react-native-webview react-native-webview-crypto
+```
+
+```shell script
+react-native link
+```
+
+Go to ios folder of your project
+
+```shell script
+pod install
 ```
 
 Also need to configure your bundler (webpack, parcel, metro, etc.) with aliases for the modules named ..-browserify
@@ -52,6 +62,17 @@ Add the line below to your `index.js` / `App.js`
 import 'react-native-get-random-values'
 ```
 
+Add following code to you jsx or tsx file where you will be calling the `signUnsignedCredential` method of the wallet
+
+```js
+import WebviewCrypto from 'react-native-webview-crypto';
+```
+Add following code to the same file in its view hierarchy as a child element
+
+```jsx
+<WebviewCrypto />
+```
+
 ### TextEncoder issue
 
 In case `TextEncoder not found` error for React Native on making bundle,
@@ -64,3 +85,4 @@ import * as encoding from 'text-encoding'
 ## How to use
 
 Please refer to [`@affinidi/wallet-core-sdk` README](https://github.com/affinityproject/affinidi-core-sdk/tree/master/sdk/core)
+


### PR DESCRIPTION
Added additional setups for react native integration while signing a credential by the sdk itself

1. Need to install `react-native-webview` `react-native-webview-crypto` via `npm`
2. Need to link it via `react-native link`
3. Do `pod install` in iOS folder
4.` import WebviewCrypto from 'react-native-webview-crypto';` and add `<WebviewCrypto /> `in view hierarchy of the jsx file where you're calling `signUnsignedCredential` method of the wallet