### PR TITLE
feat: NUC-271 fix password less flow for users with arbitrary name and changed email

### DIFF
--- a/common-libs/internal-api-clients/package-lock.json
+++ b/common-libs/internal-api-clients/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@affinidi/internal-api-clients",
-	"version": "1.2.0",
+	"version": "1.2.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@affinidi/internal-api-clients",
-			"version": "1.2.0",
+			"version": "1.2.1",
 			"license": "ISC",
 			"devDependencies": {
 				"@affinidi/eslint-config": "1.0.1",

--- a/common-libs/user-management/CHANGELOG.md
+++ b/common-libs/user-management/CHANGELOG.md
@@ -1,3 +1,7 @@
+* release 1.2.2(2022-04-08)
+  * Fix `doesConfirmedUserExist` to work with changes user email and phone
+* release 1.2.1 (2022-04-03)
+  * Fix confirmation cognito session caching for passwordless flow 
 * release 1.1.0 (2021-12-07)
   * Updated `internal-api-clients` (removing dependency on `node-fetch` and `undici`)
 # release 1.0.0 (2021-11-21)

--- a/common-libs/user-management/package-lock.json
+++ b/common-libs/user-management/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@affinidi/user-management",
-	"version": "1.2.1",
+	"version": "1.2.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@affinidi/user-management",
-			"version": "1.2.1",
+			"version": "1.2.2",
 			"license": "ISC",
 			"dependencies": {
 				"aws-sdk": "^2.1017.0",

--- a/common-libs/user-management/package.json
+++ b/common-libs/user-management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@affinidi/user-management",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "User Management implementation for AWS Cognito",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/common-libs/user-management/src/UserManagementService.ts
+++ b/common-libs/user-management/src/UserManagementService.ts
@@ -158,7 +158,8 @@ export class UserManagementService {
   }
 
   async doesUnconfirmedUserExist(username: string) {
-    return this._cognitoIdentityService.doesUnconfirmedUserExist(username)
+    const normalizedUsername = normalizeUsername(username)
+    return this._cognitoIdentityService.doesUnconfirmedUserExist(normalizedUsername)
   }
 
   async doesConfirmedUserExist(login: string) {

--- a/common-libs/user-management/src/UserManagementService.ts
+++ b/common-libs/user-management/src/UserManagementService.ts
@@ -158,13 +158,11 @@ export class UserManagementService {
   }
 
   async doesUnconfirmedUserExist(username: string) {
-    const normalizedUsername = normalizeUsername(username)
-    return this._cognitoIdentityService.doesUnconfirmedUserExist(normalizedUsername)
+    return this._cognitoIdentityService.doesUnconfirmedUserExist(username)
   }
 
   async doesConfirmedUserExist(login: string) {
-    const normalizedUsername = normalizeUsername(login)
-    return this._cognitoIdentityService.doesConfirmedUserExist(normalizedUsername)
+    return this._cognitoIdentityService.doesConfirmedUserExist(login)
   }
 
   async initiateLogInPasswordless(login: string, messageParameters?: MessageParameters): Promise<string> {

--- a/platform/fetch-node/package-lock.json
+++ b/platform/fetch-node/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@affinidi/platform-fetch-node",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@affinidi/platform-fetch-node",
-			"version": "1.0.0",
+			"version": "1.0.1",
 			"license": "ISC",
 			"dependencies": {
 				"node-fetch": "^2.6.0",

--- a/sdk/browser/CHANGELOG.md
+++ b/sdk/browser/CHANGELOG.md
@@ -1,3 +1,5 @@
+# release 6.1.2 (2022-04-08)
+fix passwordless signin for users with arbitrary user name
 # release 6.1.1 (2022-04-03)
 * Fix complete passwordless login operation
 # release 6.0.0-beta.20 (2021-10-20)

--- a/sdk/browser/package-lock.json
+++ b/sdk/browser/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@affinidi/wallet-browser-sdk",
-	"version": "6.1.1",
+	"version": "6.1.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@affinidi/wallet-browser-sdk",
-			"version": "6.1.1",
+			"version": "6.1.2",
 			"license": "ISC",
 			"dependencies": {
 				"eccrypto-js": "^5.0.0",

--- a/sdk/browser/package.json
+++ b/sdk/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@affinidi/wallet-browser-sdk",
-  "version": "6.1.1",
+  "version": "6.1.2",
   "description": "SDK monorepo for affinity DID solution for browser",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -38,7 +38,7 @@
   "license": "ISC",
   "dependencies": {
     "@affinidi/platform-fetch-native": "^1.0.0",
-    "@affinidi/wallet-core-sdk": "^6.1.1",
+    "@affinidi/wallet-core-sdk": "^6.1.2",
     "eccrypto-js": "^5.0.0",
     "randombytes": "^2.1.0"
   },

--- a/sdk/core/CHANGELOG.md
+++ b/sdk/core/CHANGELOG.md
@@ -1,3 +1,5 @@
+# release 6.1.2 (2022-04-08)
+fix passwordless signin for users with arbitrary user name 
 # release 6.1.1 (2022-04-03)
 * Fix complete passwordless login operation
 * minor fix of hashing functions for browser support

--- a/sdk/core/package-lock.json
+++ b/sdk/core/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@affinidi/wallet-core-sdk",
-	"version": "6.1.1",
+	"version": "6.1.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@affinidi/wallet-core-sdk",
-			"version": "6.1.1",
+			"version": "6.1.2",
 			"license": "ISC",
 			"dependencies": {
 				"@affinidi/affinity-metrics-lib": "^0.0.25",

--- a/sdk/core/package.json
+++ b/sdk/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@affinidi/wallet-core-sdk",
-  "version": "6.1.1",
+  "version": "6.1.2",
   "description": "SDK core monorepo for affinity DID solution",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -49,7 +49,7 @@
     "@affinidi/issuer-phone-twilio-client": "^0.1.1",
     "@affinidi/tools-common": "^1.0.0",
     "@affinidi/url-resolver": "^1.1.3",
-    "@affinidi/user-management": "^1.2.1",
+    "@affinidi/user-management": "^1.2.2",
     "@affinidi/vc-common": "^1.4.2",
     "@affinidi/vc-data": "^1.3.3",
     "ajv": "^6.12.3",

--- a/sdk/core/test/integration/otp/core.test.ts
+++ b/sdk/core/test/integration/otp/core.test.ts
@@ -574,7 +574,6 @@ parallel('CommonNetworkMember [OTP]', () => {
     })
 
     it('uncongirmed user can make signin', async () => {
-
       const newInbox = createInbox()
 
       await AffinityWallet.signUp(newInbox.email, 'nuc27!testPassword', options)

--- a/sdk/core/test/integration/otp/core.test.ts
+++ b/sdk/core/test/integration/otp/core.test.ts
@@ -580,9 +580,7 @@ parallel('CommonNetworkMember [OTP]', () => {
       await waitForOtpCode(newInbox)
       const token = await AffinidiWallet.initiateSignInPasswordless(options, newInbox.email)
       const signInOtp = await waitForOtpCode(newInbox)
-      console.log({ signInOtp })
-      const { wallet, isNew } = await AffinidiWallet.completeSignInPasswordless(options, token, signInOtp)
-      expect(isNew).to.be.equal(false)
+      const { wallet } = await AffinidiWallet.completeSignInPasswordless(options, token, signInOtp)
       checkIsWallet(wallet)
     })
 

--- a/sdk/core/test/integration/otp/core.test.ts
+++ b/sdk/core/test/integration/otp/core.test.ts
@@ -7,6 +7,7 @@ import {
   AffinidiWalletV6 as AffinidiWallet,
   AffinidiWallet as LegacyAffinidiWallet,
   checkIsWallet,
+  AffinidiWallet as AffinityWallet,
 } from '../../helpers/AffinidiWallet'
 import { SdkOptions } from '../../../src/dto/shared.dto'
 
@@ -28,7 +29,7 @@ const messageParameters: MessageParameters = {
 
 const waitForOtpCode = async (inbox: TestmailInbox): Promise<string> => {
   const { body } = await inbox.waitForNewEmail()
-  return body.replace('Your verification code is: ', '')
+  return body.match(/\d{6}/)[0]
 }
 
 const createInbox = () => new TestmailInbox({ prefix: env, suffix: 'otp.core' })
@@ -545,6 +546,31 @@ parallel('CommonNetworkMember [OTP]', () => {
 
       expect(error).to.be.instanceOf(SdkError)
       expect(error.name).to.eql('COR-7')
+    })
+
+    it('passwordless signIn after email change for arbitrary username name', async () => {
+      const generateUsername = () => {
+        const TIMESTAMP = Date.now().toString(16).toUpperCase()
+        return `test.user-${TIMESTAMP}`
+      }
+
+      const networkMemberSignUp = await AffinityWallet.signUp(generateUsername(), 'nuc27!testPassword', options)
+      checkIsWallet(networkMemberSignUp)
+
+      expect(networkMemberSignUp.did).to.exist
+      const newInbox = createInbox()
+      await networkMemberSignUp.changeUsername(newInbox.email, options)
+      const changeUsernameOtp = await waitForOtpCode(newInbox)
+
+      await networkMemberSignUp.confirmChangeUsername(newInbox.email, changeUsernameOtp, options)
+
+      await networkMemberSignUp.signOut(options)
+
+      const token = await AffinidiWallet.initiateSignInPasswordless(options, newInbox.email)
+      const signInOtp = await waitForOtpCode(newInbox)
+      const { wallet, isNew } = await AffinidiWallet.completeSignInPasswordless(options, token, signInOtp)
+      expect(isNew).to.be.equal(false)
+      checkIsWallet(wallet)
     })
 
     it('allows to change email after password was reset for user registered with email', async () => {

--- a/sdk/core/test/integration/otp/core.test.ts
+++ b/sdk/core/test/integration/otp/core.test.ts
@@ -573,6 +573,20 @@ parallel('CommonNetworkMember [OTP]', () => {
       checkIsWallet(wallet)
     })
 
+    it('uncongirmed user can make signin', async () => {
+
+      const newInbox = createInbox()
+
+      await AffinityWallet.signUp(newInbox.email, 'nuc27!testPassword', options)
+      await waitForOtpCode(newInbox)
+      const token = await AffinidiWallet.initiateSignInPasswordless(options, newInbox.email)
+      const signInOtp = await waitForOtpCode(newInbox)
+      console.log({ signInOtp })
+      const { wallet, isNew } = await AffinidiWallet.completeSignInPasswordless(options, token, signInOtp)
+      expect(isNew).to.be.equal(false)
+      checkIsWallet(wallet)
+    })
+
     it('allows to change email after password was reset for user registered with email', async () => {
       const { inbox, originalNetworkMember } = await createUser()
       await originalNetworkMember.logOut()

--- a/sdk/expo/package-lock.json
+++ b/sdk/expo/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@affinidi/wallet-expo-sdk",
-	"version": "6.1.1",
+	"version": "6.1.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@affinidi/wallet-expo-sdk",
-			"version": "6.1.1",
+			"version": "6.1.2",
 			"license": "ISC",
 			"dependencies": {
 				"assert": "^2.0.0",

--- a/sdk/expo/package.json
+++ b/sdk/expo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@affinidi/wallet-expo-sdk",
-  "version": "6.1.1",
+  "version": "6.1.2",
   "description": "SDK monorepo for affinity DID solution for Expo",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -39,7 +39,7 @@
   "license": "ISC",
   "dependencies": {
     "@affinidi/platform-fetch-native": "^1.0.0",
-    "@affinidi/wallet-core-sdk": "^6.1.1",
+    "@affinidi/wallet-core-sdk": "^6.1.2",
     "assert": "^2.0.0",
     "buffer": "^5.6.0",
     "eccrypto-js": "^5.0.0",

--- a/sdk/node/CHANGELOG.md
+++ b/sdk/node/CHANGELOG.md
@@ -1,4 +1,6 @@
-# release 6.1.1 (2022-04-03)
+# release 6.2.2 (2022-04-08)
+fix passwordless signin for users with arbitrary user name
+# release 6.2.1 (2022-04-03)
 * Fix complete passwordless login operation
 * minor fix of hashing functions for browser support
 # release 6.2.0 (2021-12-09)

--- a/sdk/node/package-lock.json
+++ b/sdk/node/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@affinidi/wallet-node-sdk",
-	"version": "6.2.1",
+	"version": "6.2.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@affinidi/wallet-node-sdk",
-			"version": "6.2.1",
+			"version": "6.2.2",
 			"license": "ISC",
 			"dependencies": {
 				"@mattrglobal/jsonld-signatures-bbs": "^0.12.0",

--- a/sdk/node/package.json
+++ b/sdk/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@affinidi/wallet-node-sdk",
-  "version": "6.2.1",
+  "version": "6.2.2",
   "description": "SDK monorepo for affinity DID solution for node",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -38,7 +38,7 @@
   "license": "ISC",
   "dependencies": {
     "@affinidi/platform-fetch-node": "^1.0.1",
-    "@affinidi/wallet-core-sdk": "^6.1.1",
+    "@affinidi/wallet-core-sdk": "^6.1.2",
     "@mattrglobal/jsonld-signatures-bbs": "^0.12.0",
     "bs58": "^4.0.1",
     "crypto-ld": "^3.9.0",

--- a/sdk/react-native/CHANGELOG.md
+++ b/sdk/react-native/CHANGELOG.md
@@ -1,3 +1,5 @@
+# release 6.1.2 (2022-04-08)
+fix passwordless signin for users with arbitrary user name
 # release 6.1.1 (2022-04-03)
 * Fix complete passwordless login operation
 * minor fix of hashing functions for browser support

--- a/sdk/react-native/package-lock.json
+++ b/sdk/react-native/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@affinidi/wallet-react-native-sdk",
-	"version": "6.1.1",
+	"version": "6.1.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@affinidi/wallet-react-native-sdk",
-			"version": "6.1.1",
+			"version": "6.1.2",
 			"license": "ISC",
 			"dependencies": {
 				"assert": "^2.0.0",

--- a/sdk/react-native/package.json
+++ b/sdk/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@affinidi/wallet-react-native-sdk",
-  "version": "6.1.1",
+  "version": "6.1.2",
   "description": "SDK for affinity DID solution for React Native",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -32,7 +32,7 @@
   "license": "ISC",
   "dependencies": {
     "@affinidi/platform-fetch-native": "^1.0.0",
-    "@affinidi/wallet-core-sdk": "^6.1.1",
+    "@affinidi/wallet-core-sdk": "^6.1.2",
     "assert": "^2.0.0",
     "buffer": "^5.6.0",
     "eccrypto-js": "^5.0.0",


### PR DESCRIPTION
Fix for NYC-271.
Bug reported by HR wallet team 
- create user with arbitrary name 
- change user email 
- use the same email for signIn 
So as result sign in flow do not identify user and do sign Up that will fail with aliase error failure 
Expected behavior - we identify that confirmed user already exist and do a login flow.

After quick investigation we identified that normalising of user name for confirmed user is a root cause.
