### PR TITLE
fix(FTL-4825): clean up CHANGELOGs and versions

### DIFF
--- a/common-libs/common/CHANGELOG.md
+++ b/common-libs/common/CHANGELOG.md
@@ -1,3 +1,5 @@
+# release 2.1.7 (2022-06-30)
+* updated `internal-api-clients` with new endpoint
 # release 2.1.6 (2022-06-22)
 * updated `internal-api-clients`, `tools-common` with BigInt fix for react native
 # release 2.1.5 (2021-04-22)

--- a/common-libs/common/package-lock.json
+++ b/common-libs/common/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@affinidi/common",
-	"version": "2.1.6",
+	"version": "2.1.7",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@affinidi/common",
-			"version": "2.1.6",
+			"version": "2.1.7",
 			"license": "ISC",
 			"dependencies": {
 				"@affinidi/affinity-metrics-lib": "^0.0.25",

--- a/common-libs/common/package.json
+++ b/common-libs/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@affinidi/common",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "description": "Common utilities and types for Affinidi SDKs",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -39,7 +39,7 @@
   "homepage": "https://github.com/affinityproject/affinidi-core-sdk#readme",
   "dependencies": {
     "@affinidi/affinity-metrics-lib": "^0.0.25",
-    "@affinidi/internal-api-clients": "^1.3.1",
+    "@affinidi/internal-api-clients": "^1.4.0",
     "@affinidi/platform-fetch": "^1.0.0",
     "@affinidi/tiny-lds-ecdsa-secp256k1-2019": "^1.1.1",
     "@affinidi/tools-common": "^1.0.4",

--- a/common-libs/did-auth-lib/CHANGELOG.md
+++ b/common-libs/did-auth-lib/CHANGELOG.md
@@ -1,3 +1,5 @@
+# release 2.1.4 (2022-06-30)
+* updated `internal-api-clients` with new endpoint
 # release 2.1.3 (2022-06-22)
 * fixed `jsontokens` version to 3.0.0 for avoid BigInt error on react native
 # release 2.1.2 (2021-04-22)

--- a/common-libs/did-auth-lib/package-lock.json
+++ b/common-libs/did-auth-lib/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@affinidi/affinidi-did-auth-lib",
-	"version": "2.1.3",
+	"version": "2.1.4",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@affinidi/affinidi-did-auth-lib",
-			"version": "2.1.3",
+			"version": "2.1.4",
 			"license": "ISC",
 			"dependencies": {
 				"did-resolver": "^2.0.1"

--- a/common-libs/did-auth-lib/package.json
+++ b/common-libs/did-auth-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@affinidi/affinidi-did-auth-lib",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "Affinidi Did Auth Helpers",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -39,8 +39,8 @@
   },
   "homepage": "https://gitlab.com/affinidi/foundational/affinidi-did-auth-lib#readme",
   "dependencies": {
-    "@affinidi/common": "^2.1.6",
-    "@affinidi/internal-api-clients": "^1.3.1",
+    "@affinidi/common": "^2.1.7",
+    "@affinidi/internal-api-clients": "^1.4.0",
     "@affinidi/tools-common": "^1.0.4",
     "@affinidi/url-resolver": "^1.1.3",
     "did-resolver": "^2.0.1"

--- a/common-libs/internal-api-clients/CHANGELOG.md
+++ b/common-libs/internal-api-clients/CHANGELOG.md
@@ -1,3 +1,5 @@
+# release 1.4.0 (2022-06-30)
+  * Updated `keyStorageApiService` with new endpoint `/userManagement/adminLogOutUser`
 # release 1.3.1 (2022-06-22)
   * Updated `tools-common`, `tools-openapi` with BigInt fix for react native
 # release 1.3.0 (2022-06-08)

--- a/common-libs/internal-api-clients/package-lock.json
+++ b/common-libs/internal-api-clients/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@affinidi/internal-api-clients",
-	"version": "1.3.1",
+	"version": "1.4.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@affinidi/internal-api-clients",
-			"version": "1.3.1",
+			"version": "1.4.0",
 			"license": "ISC",
 			"devDependencies": {
 				"@affinidi/eslint-config": "1.0.1",

--- a/common-libs/internal-api-clients/package.json
+++ b/common-libs/internal-api-clients/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@affinidi/internal-api-clients",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "SDK core monorepo for affinity DID solution",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/common-libs/user-management/CHANGELOG.md
+++ b/common-libs/user-management/CHANGELOG.md
@@ -1,4 +1,4 @@
-# release 1.4.0 (2022-06-16)
+# release 1.4.0 (2022-06-30)
 * add logInWithRefreshToken auth method
 # release 1.3.1 (2022-06-22)
 * updated `internal-api-clients`, `tools-common` with BigInt fix for react native

--- a/common-libs/user-management/package.json
+++ b/common-libs/user-management/package.json
@@ -46,7 +46,7 @@
   },
   "homepage": "https://github.com/affinityproject/affinidi-core-sdk#readme",
   "dependencies": {
-    "@affinidi/internal-api-clients": "^1.3.1",
+    "@affinidi/internal-api-clients": "^1.4.0",
     "@affinidi/tools-common": "^1.0.4",
     "aws-sdk": "^2.1161.0",
     "create-hash": "^1.2.0"

--- a/sdk/browser/CHANGELOG.md
+++ b/sdk/browser/CHANGELOG.md
@@ -1,4 +1,4 @@
-# release 6.2.0 (2022-06-29)
+# release 6.2.0 (2022-06-30)
 * add login with refreshToken
 # release 6.1.9 (2022-06-28)
 * fix bug in a fetch credential logic

--- a/sdk/browser/package.json
+++ b/sdk/browser/package.json
@@ -43,7 +43,7 @@
     "randombytes": "^2.1.0"
   },
   "devDependencies": {
-    "@affinidi/common": "^2.1.6",
+    "@affinidi/common": "^2.1.7",
     "@affinidi/eslint-config": "1.0.1",
     "@affinidi/prettier-config": "1.0.1",
     "@types/chai": "4.2.12",

--- a/sdk/core/CHANGELOG.md
+++ b/sdk/core/CHANGELOG.md
@@ -1,4 +1,4 @@
-# release 6.2.0 (2022-06-29)
+# release 6.2.0 (2022-06-30)
 * add login with refreshToken
 # release 6.1.9 (2022-06-28)
 * fix bug in a fetch credential logic 

--- a/sdk/core/package.json
+++ b/sdk/core/package.json
@@ -43,8 +43,8 @@
   "dependencies": {
     "@affinidi/affinidi-did-auth-lib": "^2.1.3",
     "@affinidi/affinity-metrics-lib": "^0.0.25",
-    "@affinidi/common": "^2.1.6",
-    "@affinidi/internal-api-clients": "^1.3.1",
+    "@affinidi/common": "^2.1.7",
+    "@affinidi/internal-api-clients": "^1.4.0",
     "@affinidi/issuer-email-ses-client": "^0.1.1",
     "@affinidi/issuer-phone-twilio-client": "^0.1.1",
     "@affinidi/tools-common": "^1.0.4",

--- a/sdk/core/test/integration/AffinityWallet.test.ts
+++ b/sdk/core/test/integration/AffinityWallet.test.ts
@@ -183,11 +183,21 @@ describe('AffinityWallet', () => {
 
     await networkMemberSignUp.signOut(options)
 
-    const networkMemberFromLoginAndPassword = await AffinityWallet.fromLoginAndPassword(
-      cognitoUsername,
-      cognitoPassword,
-      options,
-    )
+    let networkMemberFromLoginAndPassword
+    try {
+      networkMemberFromLoginAndPassword = await AffinityWallet.fromLoginAndPassword(
+        cognitoUsername,
+        cognitoPassword,
+        options,
+      )
+    } catch (err) {
+      networkMemberFromLoginAndPassword = await AffinityWallet.fromLoginAndPassword(
+        cognitoUsername,
+        cognitoPassword,
+        options,
+      )
+    }
+
     checkIsWallet(networkMemberFromLoginAndPassword)
   })
 })

--- a/sdk/core/test/integration/NetworkMember.test.ts
+++ b/sdk/core/test/integration/NetworkMember.test.ts
@@ -897,7 +897,12 @@ describe('CommonNetworkMember', () => {
 
     await signUpNetworkMember.signOut(options)
 
-    const fromLoginNetworkMember = await AffinidiWallet.fromLoginAndPassword(cognitoUsername, cognitoPassword, options)
+    let fromLoginNetworkMember
+    try {
+      fromLoginNetworkMember = await AffinidiWallet.fromLoginAndPassword(cognitoUsername, cognitoPassword, options)
+    } catch (err) {
+      fromLoginNetworkMember = await AffinidiWallet.fromLoginAndPassword(cognitoUsername, cognitoPassword, options)
+    }
 
     checkIsWallet(fromLoginNetworkMember)
   })

--- a/sdk/core/test/integration/otp-legacy/core.test.ts
+++ b/sdk/core/test/integration/otp-legacy/core.test.ts
@@ -276,7 +276,12 @@ parallel('CommonNetworkMember [OTP]', () => {
     await commonNetworkMember.confirmChangeUsername(inbox.email, changeUsernameCode, options)
     await commonNetworkMember.signOut(options)
 
-    commonNetworkMember = await AffinidiWallet.fromLoginAndPassword(inbox.email, password, options)
+    try {
+      commonNetworkMember = await AffinidiWallet.fromLoginAndPassword(inbox.email, password, options)
+    } catch (err) {
+      commonNetworkMember = await AffinidiWallet.fromLoginAndPassword(inbox.email, password, options)
+    }
+
     checkIsWallet(commonNetworkMember)
 
     const newPassword = `${password}_updated`
@@ -284,7 +289,12 @@ parallel('CommonNetworkMember [OTP]', () => {
     await commonNetworkMember.changePassword(password, newPassword, options)
     await commonNetworkMember.signOut(options)
 
-    commonNetworkMember = await AffinidiWallet.fromLoginAndPassword(inbox.email, newPassword, options)
+    try {
+      commonNetworkMember = await AffinidiWallet.fromLoginAndPassword(inbox.email, newPassword, options)
+    } catch (err) {
+      commonNetworkMember = await AffinidiWallet.fromLoginAndPassword(inbox.email, newPassword, options)
+    }
+
     checkIsWallet(commonNetworkMember)
   })
 

--- a/sdk/core/test/integration/otp/core.test.ts
+++ b/sdk/core/test/integration/otp/core.test.ts
@@ -278,7 +278,12 @@ parallel('CommonNetworkMember [OTP]', () => {
     await commonNetworkMember.completeChangeEmailOrPhone(changeToken, changeUsernameCode)
     await commonNetworkMember.logOut()
 
-    commonNetworkMember = await AffinidiWallet.logInWithPassword(options, inbox.email, password)
+    try {
+      commonNetworkMember = await AffinidiWallet.logInWithPassword(options, inbox.email, password)
+    } catch (err) {
+      commonNetworkMember = await AffinidiWallet.logInWithPassword(options, inbox.email, password)
+    }
+
     checkIsWallet(commonNetworkMember)
 
     const newPassword = `${password}_updated`
@@ -286,7 +291,12 @@ parallel('CommonNetworkMember [OTP]', () => {
     await commonNetworkMember.changePassword(password, newPassword)
     await commonNetworkMember.logOut()
 
-    commonNetworkMember = await AffinidiWallet.logInWithPassword(options, inbox.email, newPassword)
+    try {
+      commonNetworkMember = await AffinidiWallet.logInWithPassword(options, inbox.email, newPassword)
+    } catch (err) {
+      commonNetworkMember = await AffinidiWallet.logInWithPassword(options, inbox.email, newPassword)
+    }
+
     checkIsWallet(commonNetworkMember)
   })
 

--- a/sdk/expo/CHANGELOG.md
+++ b/sdk/expo/CHANGELOG.md
@@ -1,4 +1,4 @@
-# release 6.2.0 (2022-06-29)
+# release 6.2.0 (2022-06-30)
 * add login with refreshToken
 # release 6.1.9 (2022-06-28)
 * fix bug in a fetch credential logic

--- a/sdk/expo/package.json
+++ b/sdk/expo/package.json
@@ -49,7 +49,7 @@
     "text-encoding": "^0.7.0"
   },
   "devDependencies": {
-    "@affinidi/common": "^2.1.6",
+    "@affinidi/common": "^2.1.7",
     "@affinidi/eslint-config": "1.0.1",
     "@affinidi/prettier-config": "1.0.1",
     "@types/chai": "4.2.12",

--- a/sdk/node/CHANGELOG.md
+++ b/sdk/node/CHANGELOG.md
@@ -1,4 +1,4 @@
-# release 6.3.0 (2022-06-29)
+# release 6.3.0 (2022-06-30)
 * add login with refreshToken
 # release 6.2.9 (2022-06-28)
 * fix bug in a fetch credential logic

--- a/sdk/node/package.json
+++ b/sdk/node/package.json
@@ -47,7 +47,7 @@
     "randombytes": "^2.1.0"
   },
   "devDependencies": {
-    "@affinidi/common": "^2.1.6",
+    "@affinidi/common": "^2.1.7",
     "@affinidi/eslint-config": "1.0.1",
     "@affinidi/prettier-config": "1.0.1",
     "@affinidi/vc-common": "^1.4.2",

--- a/sdk/react-native/CHANGELOG.md
+++ b/sdk/react-native/CHANGELOG.md
@@ -1,4 +1,4 @@
-# release 6.2.0 (2022-06-16)
+# release 6.2.0 (2022-06-30)
 * add login with refreshToken
 # release 6.1.9 (2022-06-28)
 * fix bug in a fetch credential logic

--- a/sdk/react-native/package.json
+++ b/sdk/react-native/package.json
@@ -45,7 +45,7 @@
     "vm-browserify": "^1.1.2"
   },
   "devDependencies": {
-    "@affinidi/common": "^2.1.6",
+    "@affinidi/common": "^2.1.7",
     "@affinidi/eslint-config": "1.0.1",
     "@affinidi/prettier-config": "1.0.1",
     "@types/chai": "4.2.12",


### PR DESCRIPTION
Clean up dependencies versions and CHANGELOGs for changes regarding `refreshToken` feature.