### PR TITLE
fix: correct error codes for claim flow

### DIFF
--- a/sdk/browser/CHANGELOG.md
+++ b/sdk/browser/CHANGELOG.md
@@ -1,3 +1,5 @@
+# release 7.0.2 (2022-10-10)
+* correct error codes for claim flow
 # release 7.0.1 (2022-10-03)
 * move common errors to tools-common
 # release 7.0.0 (2022-09-28)

--- a/sdk/browser/package-lock.json
+++ b/sdk/browser/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@affinidi/wallet-browser-sdk",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/sdk/browser/package.json
+++ b/sdk/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@affinidi/wallet-browser-sdk",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "description": "SDK monorepo for affinity DID solution for browser",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -38,7 +38,7 @@
   "license": "ISC",
   "dependencies": {
     "@affinidi/platform-fetch-native": "^1.1.0",
-    "@affinidi/wallet-core-sdk": "^7.0.1",
+    "@affinidi/wallet-core-sdk": "^7.0.2",
     "eccrypto-js": "^5.0.0",
     "randombytes": "^2.1.0"
   },

--- a/sdk/core/CHANGELOG.md
+++ b/sdk/core/CHANGELOG.md
@@ -1,3 +1,5 @@
+# release 7.0.2 (2022-10-10)
+* correct error codes for claim flow
 # release 7.0.1 (2022-10-03)
 * move common errors to tools-common
 # release 7.0.0 (2022-09-28)

--- a/sdk/core/package-lock.json
+++ b/sdk/core/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@affinidi/wallet-core-sdk",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/sdk/core/package.json
+++ b/sdk/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@affinidi/wallet-core-sdk",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "description": "SDK core monorepo for affinity DID solution",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/sdk/core/src/CommonNetworkMember/BaseNetworkMember.ts
+++ b/sdk/core/src/CommonNetworkMember/BaseNetworkMember.ts
@@ -1168,15 +1168,15 @@ export abstract class BaseNetworkMember {
       })
       credentialsRequestBody = await credentialsRequest.json()
     } catch (error) {
-      throw new SdkErrorFromCode('COR-27', { callbackURL }, error)
+      throw new SdkErrorFromCode('COR-29', { callbackURL }, error)
     }
 
     if (credentialsRequest.status !== 200) {
-      throw new SdkErrorFromCode('COR-28', { callbackURL, status: credentialsRequest.status }, credentialsRequestBody)
+      throw new SdkErrorFromCode('COR-30', { callbackURL, status: credentialsRequest.status }, credentialsRequestBody)
     }
 
     if (!(credentialsRequestBody && Array.isArray(credentialsRequestBody.vcs))) {
-      throw new SdkErrorFromCode('COR-29', { callbackURL }, credentialsRequestBody)
+      throw new SdkErrorFromCode('COR-31', { callbackURL }, credentialsRequestBody)
     }
 
     return credentialsRequestBody.vcs

--- a/sdk/core/src/services/HolderService.ts
+++ b/sdk/core/src/services/HolderService.ts
@@ -232,7 +232,7 @@ export default class HolderService {
       }
 
       if (error.message === 'Signature on token is invalid') {
-        return { isValid: false, errorCode: 'COR-26', error: error.message }
+        return { isValid: false, errorCode: 'COR-28', error: error.message }
       }
 
       return { isValid: false, errorCode: '', error: error.message }

--- a/sdk/core/test/integration/NetworkMember.test.ts
+++ b/sdk/core/test/integration/NetworkMember.test.ts
@@ -1359,7 +1359,7 @@ describe('CommonNetworkMember', () => {
       await holderWallet.claimCredentials(requestForOffer)
     } catch (error) {
       const { code } = error
-      expect(code).to.eql('COR-28')
+      expect(code).to.eql('COR-30')
     }
 
     nock.cleanAll()
@@ -1385,7 +1385,7 @@ describe('CommonNetworkMember', () => {
     } catch (error) {
       console.log({ error })
       const { code } = error
-      expect(code).to.eql('COR-27')
+      expect(code).to.eql('COR-29')
     }
   })
 
@@ -1416,7 +1416,7 @@ describe('CommonNetworkMember', () => {
       await holderWallet.claimCredentials(requestForOffer)
     } catch (error) {
       const { code } = error
-      expect(code).to.eql('COR-29')
+      expect(code).to.eql('COR-31')
     }
 
     nock.cleanAll()
@@ -1475,7 +1475,7 @@ describe('CommonNetworkMember', () => {
       await holderWallet.claimCredentials(invalidRequestForOffer)
     } catch (error) {
       const { code } = error
-      expect(code).to.eql('COR-26')
+      expect(code).to.eql('COR-28')
     }
   })
 })

--- a/sdk/expo/CHANGELOG.md
+++ b/sdk/expo/CHANGELOG.md
@@ -1,3 +1,5 @@
+# release 7.0.2 (2022-10-10)
+* correct error codes for claim flow
 # release 7.0.1 (2022-10-03)
 * move common errors to tools-common
 # release 7.0.0 (2022-09-28)

--- a/sdk/expo/package-lock.json
+++ b/sdk/expo/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@affinidi/wallet-expo-sdk",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/sdk/expo/package.json
+++ b/sdk/expo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@affinidi/wallet-expo-sdk",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "description": "SDK monorepo for affinity DID solution for Expo",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -39,7 +39,7 @@
   "license": "ISC",
   "dependencies": {
     "@affinidi/platform-fetch-native": "^1.1.0",
-    "@affinidi/wallet-core-sdk": "^7.0.1",
+    "@affinidi/wallet-core-sdk": "^7.0.2",
     "assert": "^2.0.0",
     "buffer": "^5.6.0",
     "eccrypto-js": "^5.0.0",

--- a/sdk/node/CHANGELOG.md
+++ b/sdk/node/CHANGELOG.md
@@ -1,3 +1,5 @@
+# release 7.0.2 (2022-10-10)
+* correct error codes for claim flow
 # release 7.0.1 (2022-10-03)
 * move common errors to tools-common
 # release 7.0.0 (2022-09-28)

--- a/sdk/node/package-lock.json
+++ b/sdk/node/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@affinidi/wallet-node-sdk",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/sdk/node/package.json
+++ b/sdk/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@affinidi/wallet-node-sdk",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "description": "SDK monorepo for affinity DID solution for node",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -38,7 +38,7 @@
   "license": "ISC",
   "dependencies": {
     "@affinidi/platform-fetch-node": "^1.1.0",
-    "@affinidi/wallet-core-sdk": "^7.0.1",
+    "@affinidi/wallet-core-sdk": "^7.0.2",
     "@mattrglobal/jsonld-signatures-bbs": "^1.1.0",
     "bs58": "^4.0.1",
     "crypto-ld": "^3.9.0",

--- a/sdk/react-native/CHANGELOG.md
+++ b/sdk/react-native/CHANGELOG.md
@@ -1,3 +1,5 @@
+# release 7.0.2 (2022-10-10)
+* correct error codes for claim flow
 # release 7.0.1 (2022-10-03)
 * move common errors to tools-common
 # release 7.0.0 (2022-09-28)

--- a/sdk/react-native/package-lock.json
+++ b/sdk/react-native/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@affinidi/wallet-react-native-sdk",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/sdk/react-native/package.json
+++ b/sdk/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@affinidi/wallet-react-native-sdk",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "description": "SDK for affinity DID solution for React Native",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -32,7 +32,7 @@
   "license": "ISC",
   "dependencies": {
     "@affinidi/platform-fetch-native": "^1.1.0",
-    "@affinidi/wallet-core-sdk": "^7.0.1",
+    "@affinidi/wallet-core-sdk": "^7.0.2",
     "assert": "^2.0.0",
     "buffer": "^5.6.0",
     "eccrypto-js": "^5.0.0",


### PR DESCRIPTION
errors added during implementation of claim flow duplicates previously added errors for user-management. This PR fixing it while it is not used (only on our internal wallet.affinidi.com which is not handling codes, just showing error messages)