### PR TITLE
fix: update environment var to enable sysdig running properly

### DIFF
--- a/.github/workflows/sysdig-inline-scanning.yml
+++ b/.github/workflows/sysdig-inline-scanning.yml
@@ -24,7 +24,7 @@ jobs:
       uses: docker/build-push-action@v3
       with:
         context: ${{ env.DOCKERFILE_CONTEXT }}
-        tags: ${{env.REGISTRY_HOST}}/${{ env.IMAGE_NAME }}:$GITHUB_SHA
+        tags: ${{env.REGISTRY_HOST}}/${{ env.IMAGE_NAME }}:$ {{env.GITHUB_SHA}}
         load: true
     
     - name: Setup cache

--- a/.github/workflows/sysdig-inline-scanning.yml
+++ b/.github/workflows/sysdig-inline-scanning.yml
@@ -24,7 +24,7 @@ jobs:
       uses: docker/build-push-action@v3
       with:
         context: ${{ env.DOCKERFILE_CONTEXT }}
-        tags: ${{env.REGISTRY_HOST}}/${{ env.IMAGE_NAME }}:${github_sha}}
+        tags: ${{env.REGISTRY_HOST}}/${{ env.IMAGE_NAME }}:${{github_sha}}
         load: true
     
     - name: Setup cache

--- a/.github/workflows/sysdig-inline-scanning.yml
+++ b/.github/workflows/sysdig-inline-scanning.yml
@@ -24,7 +24,7 @@ jobs:
       uses: docker/build-push-action@v3
       with:
         context: ${{ env.DOCKERFILE_CONTEXT }}
-        tags: ${{env.REGISTRY_HOST}}/${{ env.IMAGE_NAME }}:${{github_sha}}
+        tags: ${{env.REGISTRY_HOST}}/${{ env.IMAGE_NAME }}:${{github.sha}}
         load: true
     
     - name: Setup cache

--- a/.github/workflows/sysdig-inline-scanning.yml
+++ b/.github/workflows/sysdig-inline-scanning.yml
@@ -24,7 +24,7 @@ jobs:
       uses: docker/build-push-action@v3
       with:
         context: ${{ env.DOCKERFILE_CONTEXT }}
-        tags: ${{env.REGISTRY_HOST}}/${{ env.IMAGE_NAME }}:${GITHUB_SHA}
+        tags: ${{env.REGISTRY_HOST}}/${{ env.IMAGE_NAME }}:$GITHUB_SHA
         load: true
     
     - name: Setup cache

--- a/.github/workflows/sysdig-inline-scanning.yml
+++ b/.github/workflows/sysdig-inline-scanning.yml
@@ -8,8 +8,8 @@ env:
 name: sysdig-inline-scanning
 
 on:
-    push:
-        branches: [master]
+  push:
+    branches: [master]
     
 
 jobs:

--- a/.github/workflows/sysdig-inline-scanning.yml
+++ b/.github/workflows/sysdig-inline-scanning.yml
@@ -7,9 +7,7 @@ env:
   
 name: sysdig-inline-scanning
 
-on:
-  push:
-    branches: [master]
+on: [push, pull_request]
     
 
 jobs:

--- a/.github/workflows/sysdig-inline-scanning.yml
+++ b/.github/workflows/sysdig-inline-scanning.yml
@@ -24,7 +24,7 @@ jobs:
       uses: docker/build-push-action@v3
       with:
         context: ${{ env.DOCKERFILE_CONTEXT }}
-        tags: ${{env.REGISTRY_HOST}}/${{ env.IMAGE_NAME }}:$ {{env.GITHUB_SHA}}
+        tags: ${{env.REGISTRY_HOST}}/${{ env.IMAGE_NAME }}:${github_sha}}
         load: true
     
     - name: Setup cache

--- a/.github/workflows/sysdig-inline-scanning.yml
+++ b/.github/workflows/sysdig-inline-scanning.yml
@@ -24,7 +24,7 @@ jobs:
       uses: docker/build-push-action@v3
       with:
         context: ${{ env.DOCKERFILE_CONTEXT }}
-        tags: ${{env.REGISTRY_HOST}}/${{ env.IMAGE_NAME }}:${{github.sha}}
+        tags: ${{env.REGISTRY_HOST}}/${{ env.IMAGE_NAME }}:${{env.IMAGE_TAG}}
         load: true
     
     - name: Setup cache

--- a/.github/workflows/sysdig-inline-scanning.yml
+++ b/.github/workflows/sysdig-inline-scanning.yml
@@ -7,7 +7,9 @@ env:
   
 name: sysdig-inline-scanning
 
-on: [push, pull_request]
+on:
+    push:
+        branches: [master]
     
 
 jobs:


### PR DESCRIPTION
Due to the wrong set up of env variable, sysdig can't accept invalid reference format. Now, it got changed to local env variable