### PR TITLE
feat: export crypto tools from sdks

### DIFF
--- a/sdk/browser/CHANGELOG.md
+++ b/sdk/browser/CHANGELOG.md
@@ -1,3 +1,5 @@
+# release 7.3.1 (2022-11-05)
+* export crypto tools
 # release 7.3.0 (2022-10-26)
 * updated `@affinidi/wallet-core-sdk` to have an option to skip call to Regisrty `anchorDid` for didMethod `elem`
 # release 7.2.0 (2022-10-20)

--- a/sdk/browser/package-lock.json
+++ b/sdk/browser/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@affinidi/wallet-browser-sdk",
-  "version": "7.3.0",
+  "version": "7.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/sdk/browser/package.json
+++ b/sdk/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@affinidi/wallet-browser-sdk",
-  "version": "7.3.0",
+  "version": "7.3.1",
   "description": "SDK monorepo for affinity DID solution for browser",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -38,7 +38,7 @@
   "license": "ISC",
   "dependencies": {
     "@affinidi/platform-fetch-native": "^1.1.0",
-    "@affinidi/wallet-core-sdk": "^7.3.0",
+    "@affinidi/wallet-core-sdk": "^7.3.1",
     "eccrypto-js": "^5.0.0",
     "randombytes": "^2.1.0"
   },

--- a/sdk/browser/src/index.ts
+++ b/sdk/browser/src/index.ts
@@ -26,3 +26,7 @@ import type * as Types from '@affinidi/wallet-core-sdk'
 export { Util } from '@affinidi/wallet-core-sdk'
 export { AffinidiWallet, AffinidiWallet as AffinityWallet, AffinidiWalletV6 } from './AffinityWallet'
 export { Types }
+
+import PlatformCryptographyTools from './PlatformCryptographyTools'
+
+export const platformCryptographyTools = PlatformCryptographyTools

--- a/sdk/core/CHANGELOG.md
+++ b/sdk/core/CHANGELOG.md
@@ -1,3 +1,5 @@
+# release 7.3.1 (2022-11-05)
+* export crypto tools
 # release 7.3.0 (2022-10-26)
 * updated `@affinidi/wallet-core-sdk` to have an option to skip call to Regisrty `anchorDid` for didMethod `elem`
 # release 7.2.0 (2022-10-20)

--- a/sdk/core/package-lock.json
+++ b/sdk/core/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@affinidi/wallet-core-sdk",
-  "version": "7.3.0",
+  "version": "7.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/sdk/core/package.json
+++ b/sdk/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@affinidi/wallet-core-sdk",
-  "version": "7.3.0",
+  "version": "7.3.1",
   "description": "SDK core monorepo for affinity DID solution",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/sdk/expo/CHANGELOG.md
+++ b/sdk/expo/CHANGELOG.md
@@ -1,3 +1,5 @@
+# release 7.3.1 (2022-11-05)
+* export crypto tools
 # release 7.3.0 (2022-10-26)
 * updated `@affinidi/wallet-core-sdk` to have an option to skip call to Regisrty `anchorDid` for didMethod `elem`
 # release 7.2.0 (2022-10-20)

--- a/sdk/expo/package-lock.json
+++ b/sdk/expo/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@affinidi/wallet-expo-sdk",
-  "version": "7.3.0",
+  "version": "7.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/sdk/expo/package.json
+++ b/sdk/expo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@affinidi/wallet-expo-sdk",
-  "version": "7.3.0",
+  "version": "7.3.1",
   "description": "SDK monorepo for affinity DID solution for Expo",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -39,7 +39,7 @@
   "license": "ISC",
   "dependencies": {
     "@affinidi/platform-fetch-native": "^1.1.0",
-    "@affinidi/wallet-core-sdk": "^7.3.0",
+    "@affinidi/wallet-core-sdk": "^7.3.1",
     "assert": "^2.0.0",
     "buffer": "^5.6.0",
     "eccrypto-js": "^5.0.0",

--- a/sdk/expo/src/index.ts
+++ b/sdk/expo/src/index.ts
@@ -39,3 +39,7 @@ import type * as Types from '@affinidi/wallet-core-sdk'
 export { Util } from '@affinidi/wallet-core-sdk'
 export { AffinidiWallet, AffinidiWallet as AffinityWallet, AffinidiWalletV6 } from './AffinityWallet'
 export { Types }
+
+import PlatformCryptographyTools from './PlatformCryptographyTools'
+
+export const platformCryptographyTools = PlatformCryptographyTools

--- a/sdk/node/CHANGELOG.md
+++ b/sdk/node/CHANGELOG.md
@@ -1,3 +1,5 @@
+# release 7.3.1 (2022-11-05)
+* export crypto tools
 # release 7.3.0 (2022-10-26)
 * updated `@affinidi/wallet-core-sdk` to have an option to skip call to Regisrty `anchorDid` for didMethod `elem`
 # release 7.2.1 (2022-10-27)

--- a/sdk/node/package-lock.json
+++ b/sdk/node/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@affinidi/wallet-node-sdk",
-  "version": "7.3.0",
+  "version": "7.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/sdk/node/package.json
+++ b/sdk/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@affinidi/wallet-node-sdk",
-  "version": "7.3.0",
+  "version": "7.3.1",
   "description": "SDK monorepo for affinity DID solution for node",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -38,7 +38,7 @@
   "license": "ISC",
   "dependencies": {
     "@affinidi/platform-fetch-node": "^1.1.0",
-    "@affinidi/wallet-core-sdk": "^7.3.0",
+    "@affinidi/wallet-core-sdk": "^7.3.1",
     "@mattrglobal/jsonld-signatures-bbs": "^1.1.0",
     "bs58": "^4.0.1",
     "crypto-ld": "^3.9.0",

--- a/sdk/node/src/index.ts
+++ b/sdk/node/src/index.ts
@@ -8,3 +8,7 @@ import type * as Types from '@affinidi/wallet-core-sdk'
 export { EventComponent, Util } from '@affinidi/wallet-core-sdk'
 export { createWallet } from './AffinityWallet'
 export { Types }
+
+import PlatformCryptographyTools from './PlatformCryptographyTools'
+
+export const platformCryptographyTools = PlatformCryptographyTools

--- a/sdk/react-native/CHANGELOG.md
+++ b/sdk/react-native/CHANGELOG.md
@@ -1,3 +1,5 @@
+# release 7.3.1 (2022-11-05)
+* export crypto tools
 # release 7.3.0 (2022-10-26)
 * updated `@affinidi/wallet-core-sdk` to have an option to skip call to Regisrty `anchorDid` for didMethod `elem`
 # release 7.2.0 (2022-10-20)

--- a/sdk/react-native/package-lock.json
+++ b/sdk/react-native/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@affinidi/wallet-react-native-sdk",
-  "version": "7.3.0",
+  "version": "7.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/sdk/react-native/package.json
+++ b/sdk/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@affinidi/wallet-react-native-sdk",
-  "version": "7.3.0",
+  "version": "7.3.1",
   "description": "SDK for affinity DID solution for React Native",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -32,7 +32,7 @@
   "license": "ISC",
   "dependencies": {
     "@affinidi/platform-fetch-native": "^1.1.0",
-    "@affinidi/wallet-core-sdk": "^7.3.0",
+    "@affinidi/wallet-core-sdk": "^7.3.1",
     "assert": "^2.0.0",
     "buffer": "^5.6.0",
     "eccrypto-js": "^5.0.0",

--- a/sdk/react-native/src/index.ts
+++ b/sdk/react-native/src/index.ts
@@ -33,3 +33,7 @@ import type * as Types from '@affinidi/wallet-core-sdk'
 export { Util } from '@affinidi/wallet-core-sdk'
 export { AffinidiWallet, AffinidiWallet as AffinityWallet, AffinidiWalletV6 } from './AffinityWallet'
 export { Types }
+
+import PlatformCryptographyTools from './PlatformCryptographyTools'
+
+export const platformCryptographyTools = PlatformCryptographyTools


### PR DESCRIPTION
In some of our project we would like to use not an SDK package, but it's crypto tools + affinidi/common